### PR TITLE
Use SIO namespace

### DIFF
--- a/nidm/nidm-experiment/terms/nidm-experiment.owl
+++ b/nidm/nidm-experiment/terms/nidm-experiment.owl
@@ -21,6 +21,7 @@
 @prefix owl2xml: <http://www.w3.org/2006/12/owl2-xml#> .
 @prefix protege: <http://protege.stanford.edu/plugins/owl/protege#> .
 @prefix oboInOwl: <http://www.geneontology.org/formats/oboInOwl#> .
+@prefix sio: <http://semanticscience.org/resource/> .
 @base <http://purl.org/nidash/nidm/experiment> .
 
 <http://purl.org/nidash/nidm/experiment> rdf:type owl:Ontology ;
@@ -354,7 +355,7 @@ dct:title rdf:type owl:DatatypeProperty .
 
 ###  http://purl.org/nidash/nidm/experiment#Data_Analysis
 
-:Data_Analysis rdf:type owl:Class ;
+sio:Data_Analysis rdf:type owl:Class ;
                
                rdfs:label "Data Analysis" ;
                
@@ -878,7 +879,7 @@ dct:title rdf:type owl:DatatypeProperty .
 
 ###  http://purl.org/nidash/nidm/experiment#Software_Execution
 
-:Software_Execution rdf:type owl:Class ;
+sio:Software_Execution rdf:type owl:Class ;
                     
                     rdfs:label "Software Execution" ;
                     


### PR DESCRIPTION
Hi @khelm,

I was just having a quick look at your PR incf-nidash/nidm#265 and it looks like the SIO terms are in the NIDM namespace, while I think they should instead be in the SIO namespace.

For example: 'Software Execution' is like this:
![screen shot 2015-03-18 at 12 09 15](https://cloud.githubusercontent.com/assets/5374264/6708384/a1ed9dee-cd67-11e4-9a18-b4a9fb5ae4cb.png)

instead of this:
![screen shot 2015-03-18 at 12 07 35](https://cloud.githubusercontent.com/assets/5374264/6708358/6ceae9da-cd67-11e4-9785-beebd7a5d090.png)

If you agree with this change, this pull request:
 - create a "sio" prefix (pointing to http://semanticscience.org/resource/) and 
 - move `Software Execution` and `Data Analysis` in the sio namespace. 

If you accept this PR, your own PR incf-nidash/nidm#265 will be automatically updated with those changes. 

If you agree with those changes, I think that there are more terms that should be moved to the "sio" namespace (for now I only moved the one with a obo:'definition source' = "SIO" attribute). If you can list the SIO terms here, I would be happy to further update the owl file in this PR. Or if you prefer to change this yourself, just let me know! 

Ideally we would also re-use the SIO identifiers (e.g. "Software Execution" is `SIO_000667`) but we can do this in a second iteration if that's ok with you?
