### PR TITLE
Small fixes in nidm-experiment.owl (open without error in Protege)

### DIFF
--- a/nidm/imports/qibo_import.ttl
+++ b/nidm/imports/qibo_import.ttl
@@ -1,4 +1,4 @@
-@prefix : <http://www.owl-ontologies.com/Ontology1298855822.owl#> .
+@prefix qibo: <http://www.owl-ontologies.com/Ontology1298855822.owl#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
@@ -18,7 +18,7 @@
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#synonym
 
-:synonym rdf:type owl:AnnotationProperty .
+qibo:synonym rdf:type owl:AnnotationProperty .
 
 
 
@@ -39,103 +39,103 @@ rdf:type rdf:type owl:AnnotationProperty .
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#ObjectProperty_11
 
-:ObjectProperty_11 rdf:type owl:ObjectProperty .
+qibo:ObjectProperty_11 rdf:type owl:ObjectProperty .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#estimates
 
-:estimates rdf:type owl:FunctionalProperty ,
+qibo:estimates rdf:type owl:FunctionalProperty ,
                     owl:InverseFunctionalProperty ,
                     owl:ObjectProperty ;
            
-           rdfs:domain :Post-processing_Algorithm ;
+           rdfs:domain qibo:Post-processing_Algorithm ;
            
-           rdfs:range :Quantitative_Imaging_Biomarker .
+           rdfs:range qibo:Quantitative_Imaging_Biomarker .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#generates
 
-:generates rdf:type owl:ObjectProperty ;
+qibo:generates rdf:type owl:ObjectProperty ;
            
-           rdfs:domain :Acquisition_Device ;
+           rdfs:domain qibo:Acquisition_Device ;
            
-           rdfs:range :Quantitative_Imaging_Biomarker ;
+           rdfs:range qibo:Quantitative_Imaging_Biomarker ;
            
-           owl:inverseOf :is_generated_by .
+           owl:inverseOf qibo:is_generated_by .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#has
 
-:has rdf:type owl:FunctionalProperty ,
+qibo:has rdf:type owl:FunctionalProperty ,
               owl:InverseFunctionalProperty ,
               owl:ObjectProperty ;
      
-     rdfs:range :Biological_Target ;
+     rdfs:range qibo:Biological_Target ;
      
-     rdfs:domain :Imaging_Subject ;
+     rdfs:domain qibo:Imaging_Subject ;
      
-     owl:inverseOf :is_present_in .
+     owl:inverseOf qibo:is_present_in .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#has_undergone
 
-:has_undergone rdf:type owl:FunctionalProperty ,
+qibo:has_undergone rdf:type owl:FunctionalProperty ,
                         owl:InverseFunctionalProperty ,
                         owl:ObjectProperty ;
                
                rdfs:label "has undergone"^^xsd:string ;
                
-               rdfs:range :Biological_Intervention ;
+               rdfs:range qibo:Biological_Intervention ;
                
-               rdfs:domain :Imaging_Subject .
+               rdfs:domain qibo:Imaging_Subject .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#images
 
-:images rdf:type owl:FunctionalProperty ,
+qibo:images rdf:type owl:FunctionalProperty ,
                  owl:InverseFunctionalProperty ,
                  owl:ObjectProperty ;
         
-        rdfs:domain :Acquisition_Device ;
+        rdfs:domain qibo:Acquisition_Device ;
         
-        rdfs:range :Imaging_Subject .
+        rdfs:range qibo:Imaging_Subject .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#influences
 
-:influences rdf:type owl:FunctionalProperty ,
+qibo:influences rdf:type owl:FunctionalProperty ,
                      owl:InverseFunctionalProperty ,
                      owl:ObjectProperty ;
             
-            rdfs:domain :Biological_Intervention ;
+            rdfs:domain qibo:Biological_Intervention ;
             
-            rdfs:range :Biological_Target ;
+            rdfs:range qibo:Biological_Target ;
             
-            owl:inverseOf :is_influenced_by .
+            owl:inverseOf qibo:is_influenced_by .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#involves
 
-:involves rdf:type owl:FunctionalProperty ,
+qibo:involves rdf:type owl:FunctionalProperty ,
                    owl:InverseFunctionalProperty ,
                    owl:ObjectProperty ;
           
-          rdfs:range :Biological_Target ;
+          rdfs:range qibo:Biological_Target ;
           
-          rdfs:domain :Indicated_Biology .
+          rdfs:domain qibo:Indicated_Biology .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#is_a_biomarker_for
 
-:is_a_biomarker_for rdf:type owl:FunctionalProperty ,
+qibo:is_a_biomarker_for rdf:type owl:FunctionalProperty ,
                              owl:ObjectProperty ;
                     
                     rdfs:label "is a biomarker for"^^xsd:string .
@@ -144,7 +144,7 @@ rdf:type rdf:type owl:AnnotationProperty .
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#is_a_change_in_measurement
 
-:is_a_change_in_measurement rdf:type owl:FunctionalProperty ,
+qibo:is_a_change_in_measurement rdf:type owl:FunctionalProperty ,
                                      owl:ObjectProperty ;
                             
                             rdfs:label "is a change in measurement"^^xsd:string ;
@@ -152,7 +152,7 @@ rdf:type rdf:type owl:AnnotationProperty .
                             rdfs:comment "When the measurement is a change in some other parameter, such as an increase in diameter."^^xsd:string ;
                             
                             rdfs:domain [ rdf:type owl:Class ;
-                                          owl:unionOf ( :Measurement_of_Change
+                                          owl:unionOf ( qibo:Measurement_of_Change
                                                         owl:Thing
                                                       )
                                         ] .
@@ -161,49 +161,49 @@ rdf:type rdf:type owl:AnnotationProperty .
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#is_administered_to
 
-:is_administered_to rdf:type owl:FunctionalProperty ,
+qibo:is_administered_to rdf:type owl:FunctionalProperty ,
                              owl:InverseFunctionalProperty ,
                              owl:ObjectProperty ;
                     
-                    rdfs:domain :Imaging_Agent ;
+                    rdfs:domain qibo:Imaging_Agent ;
                     
-                    rdfs:range :Imaging_Subject .
+                    rdfs:range qibo:Imaging_Subject .
 
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#is_administered_with
 
-:is_administered_with rdf:type owl:FunctionalProperty ,
+qibo:is_administered_with rdf:type owl:FunctionalProperty ,
                                owl:InverseFunctionalProperty ,
                                owl:ObjectProperty ;
                       
-                      rdfs:range :Imaging_Agent ;
+                      rdfs:range qibo:Imaging_Agent ;
                       
-                      rdfs:domain :Imaging_Subject ;
+                      rdfs:domain qibo:Imaging_Subject ;
                       
-                      owl:inverseOf :is_administered_to .
+                      owl:inverseOf qibo:is_administered_to .
 
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#is_applicable_to
 
-:is_applicable_to rdf:type owl:FunctionalProperty ,
+qibo:is_applicable_to rdf:type owl:FunctionalProperty ,
                            owl:InverseFunctionalProperty ,
                            owl:ObjectProperty ;
                   
-                  rdfs:range :Biomarker_Use ;
+                  rdfs:range qibo:Biomarker_Use ;
                   
-                  rdfs:domain :Indicated_Biology ;
+                  rdfs:domain qibo:Indicated_Biology ;
                   
-                  owl:inverseOf :pertains_to .
+                  owl:inverseOf qibo:pertains_to .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#is_applied_to
 
-:is_applied_to rdf:type owl:ObjectProperty ;
+qibo:is_applied_to rdf:type owl:ObjectProperty ;
                
                rdfs:label "is applied to"^^xsd:string .
 
@@ -213,7 +213,7 @@ rdf:type rdf:type owl:AnnotationProperty .
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#is_biomarker_of
 
-:is_biomarker_of rdf:type owl:FunctionalProperty ,
+qibo:is_biomarker_of rdf:type owl:FunctionalProperty ,
                           owl:ObjectProperty ;
                  
                  rdfs:label "is biomarker of"^^xsd:string .
@@ -222,7 +222,7 @@ rdf:type rdf:type owl:AnnotationProperty .
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#is_derived_from
 
-:is_derived_from rdf:type owl:FunctionalProperty ,
+qibo:is_derived_from rdf:type owl:FunctionalProperty ,
                           owl:ObjectProperty ;
                  
                  rdfs:label "is derived from"^^xsd:string .
@@ -231,39 +231,39 @@ rdf:type rdf:type owl:AnnotationProperty .
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#is_enhanced_by
 
-:is_enhanced_by rdf:type owl:FunctionalProperty ,
+qibo:is_enhanced_by rdf:type owl:FunctionalProperty ,
                          owl:InverseFunctionalProperty ,
                          owl:ObjectProperty ;
                 
-                rdfs:domain :Biological_Target ;
+                rdfs:domain qibo:Biological_Target ;
                 
-                rdfs:range :Imaging_Agent .
+                rdfs:range qibo:Imaging_Agent .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#is_estimated_by
 
-:is_estimated_by rdf:type owl:FunctionalProperty ,
+qibo:is_estimated_by rdf:type owl:FunctionalProperty ,
                           owl:InverseFunctionalProperty ,
                           owl:ObjectProperty ;
                  
-                 rdfs:range :Post-processing_Algorithm ;
+                 rdfs:range qibo:Post-processing_Algorithm ;
                  
-                 rdfs:domain :Quantitative_Imaging_Biomarker ;
+                 rdfs:domain qibo:Quantitative_Imaging_Biomarker ;
                  
-                 owl:inverseOf :estimates .
+                 owl:inverseOf qibo:estimates .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#is_from_source
 
-:is_from_source rdf:type owl:FunctionalProperty ,
+qibo:is_from_source rdf:type owl:FunctionalProperty ,
                          owl:ObjectProperty ;
                 
                 rdfs:label "is from source"^^xsd:string ;
                 
                 rdfs:domain [ rdf:type owl:Class ;
-                              owl:unionOf ( :In_vitro_subject
+                              owl:unionOf ( qibo:In_vitro_subject
                                             owl:Thing
                                           )
                             ] .
@@ -272,16 +272,16 @@ rdf:type rdf:type owl:AnnotationProperty .
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#is_generated_by
 
-:is_generated_by rdf:type owl:FunctionalProperty ,
+qibo:is_generated_by rdf:type owl:FunctionalProperty ,
                           owl:InverseFunctionalProperty ,
                           owl:ObjectProperty ;
                  
                  rdfs:label "is generated by"^^xsd:string ;
                  
-                 rdfs:range :Acquisition_Device ;
+                 rdfs:range qibo:Acquisition_Device ;
                  
                  rdfs:domain [ rdf:type owl:Class ;
-                               owl:unionOf ( :Quantitative_Imaging_Biomarker
+                               owl:unionOf ( qibo:Quantitative_Imaging_Biomarker
                                              owl:Thing
                                            )
                              ] .
@@ -290,7 +290,7 @@ rdf:type rdf:type owl:AnnotationProperty .
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#is_imaged_with
 
-:is_imaged_with rdf:type owl:FunctionalProperty ,
+qibo:is_imaged_with rdf:type owl:FunctionalProperty ,
                          owl:InverseFunctionalProperty ,
                          owl:ObjectProperty ;
                 
@@ -298,12 +298,12 @@ rdf:type rdf:type owl:AnnotationProperty .
                 
                 rdfs:comment "Only the biological subject is imaged.  We do not consider the Target or the Agent to be imaged, since they are within the subject, which is being imaged."^^xsd:string ;
                 
-                rdfs:range :Acquisition_Device ;
+                rdfs:range qibo:Acquisition_Device ;
                 
-                owl:inverseOf :images ;
+                owl:inverseOf qibo:images ;
                 
                 rdfs:domain [ rdf:type owl:Class ;
-                              owl:unionOf ( :Imaging_Subject
+                              owl:unionOf ( qibo:Imaging_Subject
                                             owl:Thing
                                           )
                             ] .
@@ -312,13 +312,13 @@ rdf:type rdf:type owl:AnnotationProperty .
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#is_implemented_by
 
-:is_implemented_by rdf:type owl:FunctionalProperty ,
+qibo:is_implemented_by rdf:type owl:FunctionalProperty ,
                             owl:InverseFunctionalProperty ,
                             owl:ObjectProperty ;
                    
-                   rdfs:range :Acquisition_Device ;
+                   rdfs:range qibo:Acquisition_Device ;
                    
-                   rdfs:domain :Imaging_Technique .
+                   rdfs:domain qibo:Imaging_Technique .
 
 
 
@@ -326,41 +326,41 @@ rdf:type rdf:type owl:AnnotationProperty .
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#is_influenced_by
 
-:is_influenced_by rdf:type owl:FunctionalProperty ,
+qibo:is_influenced_by rdf:type owl:FunctionalProperty ,
                            owl:InverseFunctionalProperty ,
                            owl:ObjectProperty ;
                   
-                  rdfs:range :Biological_Intervention ;
+                  rdfs:range qibo:Biological_Intervention ;
                   
-                  rdfs:domain :Biological_Target .
+                  rdfs:domain qibo:Biological_Target .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#is_measured_by
 
-:is_measured_by rdf:type owl:FunctionalProperty ,
+qibo:is_measured_by rdf:type owl:FunctionalProperty ,
                          owl:InverseFunctionalProperty ,
                          owl:ObjectProperty ;
                 
                 rdfs:label "is measured by"^^xsd:string ;
                 
-                rdfs:domain :Biological_Target ;
+                rdfs:domain qibo:Biological_Target ;
                 
-                rdfs:range :Quantitative_Imaging_Biomarker ;
+                rdfs:range qibo:Quantitative_Imaging_Biomarker ;
                 
-                owl:inverseOf :measures .
+                owl:inverseOf qibo:measures .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#is_measured_relative_to
 
-:is_measured_relative_to rdf:type owl:FunctionalProperty ,
+qibo:is_measured_relative_to rdf:type owl:FunctionalProperty ,
                                   owl:ObjectProperty ;
                          
                          rdfs:label "is measured relative to"^^xsd:string ;
                          
                          rdfs:domain [ rdf:type owl:Class ;
-                                       owl:unionOf ( :Locational_Parameter
+                                       owl:unionOf ( qibo:Locational_Parameter
                                                      owl:Thing
                                                    )
                                      ] .
@@ -369,69 +369,69 @@ rdf:type rdf:type owl:AnnotationProperty .
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#is_measurement_of
 
-:is_measurement_of rdf:type owl:FunctionalProperty ,
+qibo:is_measurement_of rdf:type owl:FunctionalProperty ,
                             owl:ObjectProperty ;
                    
                    rdfs:label "is measurement of"^^xsd:string ;
                    
-                   rdfs:range :Indicated_Biology ;
+                   rdfs:range qibo:Indicated_Biology ;
                    
-                   rdfs:domain :Quantitative_Imaging_Biomarker ;
+                   rdfs:domain qibo:Quantitative_Imaging_Biomarker ;
                    
-                   owl:inverseOf :is_quantified_by .
+                   owl:inverseOf qibo:is_quantified_by .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#is_of_modality
 
-:is_of_modality rdf:type owl:FunctionalProperty ,
+qibo:is_of_modality rdf:type owl:FunctionalProperty ,
                          owl:InverseFunctionalProperty ,
                          owl:ObjectProperty ;
                 
-                rdfs:range :Acquisition_Device ;
+                rdfs:range qibo:Acquisition_Device ;
                 
-                rdfs:domain :Imaging_Agent .
+                rdfs:domain qibo:Imaging_Agent .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#is_performed_on
 
-:is_performed_on rdf:type owl:FunctionalProperty ,
+qibo:is_performed_on rdf:type owl:FunctionalProperty ,
                           owl:InverseFunctionalProperty ,
                           owl:ObjectProperty ;
                  
-                 rdfs:domain :Biological_Intervention ;
+                 rdfs:domain qibo:Biological_Intervention ;
                  
-                 rdfs:range :Imaging_Subject ;
+                 rdfs:range qibo:Imaging_Subject ;
                  
-                 owl:inverseOf :has_undergone .
+                 owl:inverseOf qibo:has_undergone .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#is_present_in
 
-:is_present_in rdf:type owl:FunctionalProperty ,
+qibo:is_present_in rdf:type owl:FunctionalProperty ,
                         owl:InverseFunctionalProperty ,
                         owl:ObjectProperty ;
                
-               rdfs:domain :Biological_Target ;
+               rdfs:domain qibo:Biological_Target ;
                
-               rdfs:range :Imaging_Subject .
+               rdfs:range qibo:Imaging_Subject .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#is_quantified_by
 
-:is_quantified_by rdf:type owl:FunctionalProperty ,
+qibo:is_quantified_by rdf:type owl:FunctionalProperty ,
                            owl:InverseFunctionalProperty ,
                            owl:ObjectProperty ;
                   
                   rdfs:label "is quantified by"^^xsd:string ;
                   
-                  rdfs:range :Quantitative_Imaging_Biomarker ;
+                  rdfs:range qibo:Quantitative_Imaging_Biomarker ;
                   
                   rdfs:domain [ rdf:type owl:Class ;
-                                owl:unionOf ( :Indicated_Biology
+                                owl:unionOf ( qibo:Indicated_Biology
                                               owl:Thing
                                             )
                               ] .
@@ -440,7 +440,7 @@ rdf:type rdf:type owl:AnnotationProperty .
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#is_targetted_by
 
-:is_targetted_by rdf:type owl:FunctionalProperty ,
+qibo:is_targetted_by rdf:type owl:FunctionalProperty ,
                           owl:ObjectProperty ;
                  
                  rdfs:label "is targetted by"^^xsd:string ;
@@ -451,52 +451,52 @@ rdf:type rdf:type owl:AnnotationProperty .
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#is_used_in
 
-:is_used_in rdf:type owl:ObjectProperty ;
+qibo:is_used_in rdf:type owl:ObjectProperty ;
             
-            rdfs:range :Biomarker_Use .
+            rdfs:range qibo:Biomarker_Use .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#is_used_in_subject
 
-:is_used_in_subject rdf:type owl:FunctionalProperty ,
+qibo:is_used_in_subject rdf:type owl:FunctionalProperty ,
                              owl:InverseFunctionalProperty ,
                              owl:ObjectProperty ;
                     
-                    rdfs:domain :Biomarker_Use ;
+                    rdfs:domain qibo:Biomarker_Use ;
                     
-                    rdfs:range :Imaging_Subject ;
+                    rdfs:range qibo:Imaging_Subject ;
                     
-                    owl:inverseOf :is_benefit_from .
+                    owl:inverseOf qibo:is_benefit_from .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#measures
 
-:measures rdf:type owl:InverseFunctionalProperty ,
+qibo:measures rdf:type owl:InverseFunctionalProperty ,
                    owl:ObjectProperty ;
           
-          rdfs:range :Biological_Target ;
+          rdfs:range qibo:Biological_Target ;
           
-          rdfs:domain :Quantitative_Imaging_Biomarker .
+          rdfs:domain qibo:Quantitative_Imaging_Biomarker .
 
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#participates_in
 
-:participates_in rdf:type owl:FunctionalProperty ,
+qibo:participates_in rdf:type owl:FunctionalProperty ,
                           owl:InverseFunctionalProperty ,
                           owl:ObjectProperty ;
                  
                  rdfs:label "participates in"^^xsd:string ;
                  
-                 rdfs:range :Indicated_Biology ;
+                 rdfs:range qibo:Indicated_Biology ;
                  
-                 owl:inverseOf :involves ;
+                 owl:inverseOf qibo:involves ;
                  
                  rdfs:domain [ rdf:type owl:Class ;
-                               owl:unionOf ( :Biological_Target
+                               owl:unionOf ( qibo:Biological_Target
                                              owl:Thing
                                            )
                              ] .
@@ -505,24 +505,24 @@ rdf:type rdf:type owl:AnnotationProperty .
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#pertains_to
 
-:pertains_to rdf:type owl:FunctionalProperty ,
+qibo:pertains_to rdf:type owl:FunctionalProperty ,
                       owl:InverseFunctionalProperty ,
                       owl:ObjectProperty ;
              
-             rdfs:domain :Biomarker_Use ;
+             rdfs:domain qibo:Biomarker_Use ;
              
-             rdfs:range :Indicated_Biology .
+             rdfs:range qibo:Indicated_Biology .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#requires_parameter
 
-:requires_parameter rdf:type owl:ObjectProperty ;
+qibo:requires_parameter rdf:type owl:ObjectProperty ;
                     
                     rdfs:label "requires parameter"^^xsd:string ;
                     
                     rdfs:domain [ rdf:type owl:Class ;
-                                  owl:unionOf ( :Post-processing_Algorithm
+                                  owl:unionOf ( qibo:Post-processing_Algorithm
                                                 owl:Thing
                                               )
                                 ] .
@@ -531,12 +531,12 @@ rdf:type rdf:type owl:AnnotationProperty .
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#requires_preceding_algorithm
 
-:requires_preceding_algorithm rdf:type owl:ObjectProperty ;
+qibo:requires_preceding_algorithm rdf:type owl:ObjectProperty ;
                               
                               rdfs:label "requires preceding algorithm"^^xsd:string ;
                               
                               rdfs:domain [ rdf:type owl:Class ;
-                                            owl:unionOf ( :Post-processing_Algorithm
+                                            owl:unionOf ( qibo:Post-processing_Algorithm
                                                           owl:Thing
                                                         )
                                           ] .
@@ -545,12 +545,12 @@ rdf:type rdf:type owl:AnnotationProperty .
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#results_in_parameter
 
-:results_in_parameter rdf:type owl:ObjectProperty ;
+qibo:results_in_parameter rdf:type owl:ObjectProperty ;
                       
                       rdfs:label "results in parameter"^^xsd:string ;
                       
                       rdfs:domain [ rdf:type owl:Class ;
-                                    owl:unionOf ( :Post-processing_Algorithm
+                                    owl:unionOf ( qibo:Post-processing_Algorithm
                                                   owl:Thing
                                                 )
                                   ] .
@@ -559,7 +559,7 @@ rdf:type rdf:type owl:AnnotationProperty .
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#targeting
 
-:targeting rdf:type owl:FunctionalProperty ,
+qibo:targeting rdf:type owl:FunctionalProperty ,
                     owl:ObjectProperty ;
            
            rdfs:label "targeting"^^xsd:string .
@@ -568,67 +568,67 @@ rdf:type rdf:type owl:AnnotationProperty .
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#used_for
 
-:used_for rdf:type owl:FunctionalProperty ,
+qibo:used_for rdf:type owl:FunctionalProperty ,
                    owl:InverseFunctionalProperty ,
                    owl:ObjectProperty ;
           
           rdfs:label "is used for"^^xsd:string ;
           
-          rdfs:range :Biomarker_Use ;
+          rdfs:range qibo:Biomarker_Use ;
           
-          rdfs:domain :Quantitative_Imaging_Biomarker ;
+          rdfs:domain qibo:Quantitative_Imaging_Biomarker ;
           
-          owl:inverseOf :uses .
+          owl:inverseOf qibo:uses .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#used_with
 
-:used_with rdf:type owl:ObjectProperty ;
+qibo:used_with rdf:type owl:ObjectProperty ;
            
-           rdfs:range :Imaging_Agent ;
+           rdfs:range qibo:Imaging_Agent ;
            
-           rdfs:domain :Imaging_Technique .
+           rdfs:domain qibo:Imaging_Technique .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#uses
 
-:uses rdf:type owl:FunctionalProperty ,
+qibo:uses rdf:type owl:FunctionalProperty ,
                owl:InverseFunctionalProperty ,
                owl:ObjectProperty ;
       
-      rdfs:domain :Biomarker_Use ;
+      rdfs:domain qibo:Biomarker_Use ;
       
-      rdfs:range :Quantitative_Imaging_Biomarker .
+      rdfs:range qibo:Quantitative_Imaging_Biomarker .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#uses_image_techniques
 
-:uses_image_techniques rdf:type owl:FunctionalProperty ,
+qibo:uses_image_techniques rdf:type owl:FunctionalProperty ,
                                 owl:InverseFunctionalProperty ,
                                 owl:ObjectProperty ;
                        
-                       rdfs:domain :Acquisition_Device ;
+                       rdfs:domain qibo:Acquisition_Device ;
                        
-                       rdfs:range :Imaging_Technique ;
+                       rdfs:range qibo:Imaging_Technique ;
                        
-                       owl:inverseOf :is_implemented_by .
+                       owl:inverseOf qibo:is_implemented_by .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#uses_imaging_agent
 
-:uses_imaging_agent rdf:type owl:FunctionalProperty ,
+qibo:uses_imaging_agent rdf:type owl:FunctionalProperty ,
                              owl:InverseFunctionalProperty ,
                              owl:ObjectProperty ;
                     
-                    rdfs:domain :Acquisition_Device ;
+                    rdfs:domain qibo:Acquisition_Device ;
                     
-                    rdfs:range :Imaging_Agent ;
+                    rdfs:range qibo:Imaging_Agent ;
                     
-                    owl:inverseOf :is_of_modality .
+                    owl:inverseOf qibo:is_of_modality .
 
 
 
@@ -643,7 +643,7 @@ rdf:type rdf:type owl:AnnotationProperty .
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Emitter
 
-:Emitter rdf:type owl:DatatypeProperty ,
+qibo:Emitter rdf:type owl:DatatypeProperty ,
                   owl:FunctionalProperty ;
          
          rdfs:label "Emitter"^^xsd:string ;
@@ -651,7 +651,7 @@ rdf:type rdf:type owl:AnnotationProperty .
          rdfs:range xsd:string ;
          
          rdfs:domain [ rdf:type owl:Class ;
-                       owl:unionOf ( :Radionuclide
+                       owl:unionOf ( qibo:Radionuclide
                                      owl:Thing
                                    )
                      ] .
@@ -660,7 +660,7 @@ rdf:type rdf:type owl:AnnotationProperty .
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Genetic_background
 
-:Genetic_background rdf:type owl:DatatypeProperty ,
+qibo:Genetic_background rdf:type owl:DatatypeProperty ,
                              owl:FunctionalProperty ;
                     
                     rdfs:label "Genetic background"^^xsd:string ;
@@ -676,7 +676,7 @@ genetic background may be instances of Mouse"""^^xsd:string ;
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#affinity
 
-:affinity rdf:type owl:DatatypeProperty ,
+qibo:affinity rdf:type owl:DatatypeProperty ,
                    owl:FunctionalProperty ;
           
           rdfs:label "affinity"^^xsd:string ;
@@ -684,7 +684,7 @@ genetic background may be instances of Mouse"""^^xsd:string ;
           rdfs:range xsd:string ;
           
           rdfs:domain [ rdf:type owl:Class ;
-                        owl:unionOf ( :Imaging_Agent
+                        owl:unionOf ( qibo:Imaging_Agent
                                       owl:Thing
                                     )
                       ] .
@@ -693,7 +693,7 @@ genetic background may be instances of Mouse"""^^xsd:string ;
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#binding_affinity__Ki_
 
-:binding_affinity__Ki_ rdf:type owl:DatatypeProperty ,
+qibo:binding_affinity__Ki_ rdf:type owl:DatatypeProperty ,
                                 owl:FunctionalProperty ;
                        
                        rdfs:label "binding affinity (Ki)"^^xsd:string ;
@@ -704,7 +704,7 @@ genetic background may be instances of Mouse"""^^xsd:string ;
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#biodistribution
 
-:biodistribution rdf:type owl:DatatypeProperty ,
+qibo:biodistribution rdf:type owl:DatatypeProperty ,
                           owl:FunctionalProperty ;
                  
                  rdfs:label "biodistribution"^^xsd:string ;
@@ -712,7 +712,7 @@ genetic background may be instances of Mouse"""^^xsd:string ;
                  rdfs:range xsd:string ;
                  
                  rdfs:domain [ rdf:type owl:Class ;
-                               owl:unionOf ( :Imaging_Agent
+                               owl:unionOf ( qibo:Imaging_Agent
                                              owl:Thing
                                            )
                              ] .
@@ -723,7 +723,7 @@ genetic background may be instances of Mouse"""^^xsd:string ;
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#dose
 
-:dose rdf:type owl:DatatypeProperty ,
+qibo:dose rdf:type owl:DatatypeProperty ,
                owl:FunctionalProperty ;
       
       rdfs:label "dose"^^xsd:string ;
@@ -731,7 +731,7 @@ genetic background may be instances of Mouse"""^^xsd:string ;
       rdfs:range xsd:string ;
       
       rdfs:domain [ rdf:type owl:Class ;
-                    owl:unionOf ( :Induced_gene_expression
+                    owl:unionOf ( qibo:Induced_gene_expression
                                   owl:Thing
                                 )
                   ] .
@@ -740,7 +740,7 @@ genetic background may be instances of Mouse"""^^xsd:string ;
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#emission_spectrum
 
-:emission_spectrum rdf:type owl:DatatypeProperty ,
+qibo:emission_spectrum rdf:type owl:DatatypeProperty ,
                             owl:FunctionalProperty ;
                    
                    rdfs:label "emission_spectrum"^^xsd:string ;
@@ -748,7 +748,7 @@ genetic background may be instances of Mouse"""^^xsd:string ;
                    rdfs:range xsd:float ;
                    
                    rdfs:domain [ rdf:type owl:Class ;
-                                 owl:unionOf ( :Optical
+                                 owl:unionOf ( qibo:Optical
                                                owl:Thing
                                              )
                                ] .
@@ -757,7 +757,7 @@ genetic background may be instances of Mouse"""^^xsd:string ;
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#emission_wavelength
 
-:emission_wavelength rdf:type owl:DatatypeProperty ,
+qibo:emission_wavelength rdf:type owl:DatatypeProperty ,
                               owl:FunctionalProperty ;
                      
                      rdfs:label "emission_wavelength"^^xsd:string ;
@@ -765,7 +765,7 @@ genetic background may be instances of Mouse"""^^xsd:string ;
                      rdfs:range xsd:float ;
                      
                      rdfs:domain [ rdf:type owl:Class ;
-                                   owl:unionOf ( :Optical
+                                   owl:unionOf ( qibo:Optical
                                                  owl:Thing
                                                )
                                  ] .
@@ -774,14 +774,14 @@ genetic background may be instances of Mouse"""^^xsd:string ;
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#energy
 
-:energy rdf:type owl:DatatypeProperty ;
+qibo:energy rdf:type owl:DatatypeProperty ;
         
         rdfs:label "energy"^^xsd:string ;
         
         rdfs:range xsd:string ;
         
         rdfs:domain [ rdf:type owl:Class ;
-                      owl:unionOf ( :Radionuclide
+                      owl:unionOf ( qibo:Radionuclide
                                     owl:Thing
                                   )
                     ] .
@@ -791,7 +791,7 @@ genetic background may be instances of Mouse"""^^xsd:string ;
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#excitation_spectrum
 
-:excitation_spectrum rdf:type owl:DatatypeProperty ,
+qibo:excitation_spectrum rdf:type owl:DatatypeProperty ,
                               owl:FunctionalProperty ;
                      
                      rdfs:label "excitation_spectrum"^^xsd:string ;
@@ -799,7 +799,7 @@ genetic background may be instances of Mouse"""^^xsd:string ;
                      rdfs:range xsd:float ;
                      
                      rdfs:domain [ rdf:type owl:Class ;
-                                   owl:unionOf ( :Optical
+                                   owl:unionOf ( qibo:Optical
                                                  owl:Thing
                                                )
                                  ] .
@@ -808,7 +808,7 @@ genetic background may be instances of Mouse"""^^xsd:string ;
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#excretion
 
-:excretion rdf:type owl:DatatypeProperty ,
+qibo:excretion rdf:type owl:DatatypeProperty ,
                     owl:FunctionalProperty ;
            
            rdfs:label "excretion"^^xsd:string ;
@@ -816,7 +816,7 @@ genetic background may be instances of Mouse"""^^xsd:string ;
            rdfs:range xsd:string ;
            
            rdfs:domain [ rdf:type owl:Class ;
-                         owl:unionOf ( :Imaging_Agent
+                         owl:unionOf ( qibo:Imaging_Agent
                                        owl:Thing
                                      )
                        ] .
@@ -826,7 +826,7 @@ genetic background may be instances of Mouse"""^^xsd:string ;
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#gene_knockin_or_knockout
 
-:gene_knockin_or_knockout rdf:type owl:DatatypeProperty ,
+qibo:gene_knockin_or_knockout rdf:type owl:DatatypeProperty ,
                                    owl:FunctionalProperty ;
                           
                           rdfs:label "gene knockin or knockout"^^xsd:string ;
@@ -834,7 +834,7 @@ genetic background may be instances of Mouse"""^^xsd:string ;
                           rdfs:range xsd:string ;
                           
                           rdfs:domain [ rdf:type owl:Class ;
-                                        owl:unionOf ( :Genetically_engineered_mutant_mouse
+                                        owl:unionOf ( qibo:Genetically_engineered_mutant_mouse
                                                       owl:Thing
                                                     )
                                       ] .
@@ -843,7 +843,7 @@ genetic background may be instances of Mouse"""^^xsd:string ;
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#genetic_background
 
-:genetic_background rdf:type owl:DatatypeProperty ,
+qibo:genetic_background rdf:type owl:DatatypeProperty ,
                              owl:FunctionalProperty ;
                     
                     rdfs:label "genetic background"^^xsd:string ;
@@ -853,7 +853,7 @@ genetic background may be instances of Mouse"""^^xsd:string ;
                     rdfs:range xsd:string ;
                     
                     rdfs:domain [ rdf:type owl:Class ;
-                                  owl:unionOf ( :Genetically_engineered_mutant_mouse
+                                  owl:unionOf ( qibo:Genetically_engineered_mutant_mouse
                                                 owl:Thing
                                               )
                                 ] .
@@ -862,7 +862,7 @@ genetic background may be instances of Mouse"""^^xsd:string ;
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#half_life
 
-:half_life rdf:type owl:DatatypeProperty ,
+qibo:half_life rdf:type owl:DatatypeProperty ,
                     owl:FunctionalProperty ;
            
            rdfs:label "half life"^^xsd:string ;
@@ -870,7 +870,7 @@ genetic background may be instances of Mouse"""^^xsd:string ;
            rdfs:range xsd:string ;
            
            rdfs:domain [ rdf:type owl:Class ;
-                         owl:unionOf ( :Radionuclide
+                         owl:unionOf ( qibo:Radionuclide
                                        owl:Thing
                                      )
                        ] .
@@ -879,7 +879,7 @@ genetic background may be instances of Mouse"""^^xsd:string ;
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#has_been_treated_with
 
-:has_been_treated_with rdf:type owl:DatatypeProperty ,
+qibo:has_been_treated_with rdf:type owl:DatatypeProperty ,
                                 owl:FunctionalProperty ;
                        
                        rdfs:label "has been treated with"^^xsd:string ;
@@ -890,7 +890,7 @@ genetic background may be instances of Mouse"""^^xsd:string ;
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#has_temporality
 
-:has_temporality rdf:type owl:DatatypeProperty ,
+qibo:has_temporality rdf:type owl:DatatypeProperty ,
                           owl:FunctionalProperty ;
                  
                  rdfs:label "has temporality"^^xsd:string ;
@@ -898,7 +898,7 @@ genetic background may be instances of Mouse"""^^xsd:string ;
                  rdfs:range xsd:string ;
                  
                  rdfs:domain [ rdf:type owl:Class ;
-                               owl:unionOf ( :Quantitative_Imaging_Biomarker
+                               owl:unionOf ( qibo:Quantitative_Imaging_Biomarker
                                              owl:Thing
                                            )
                              ] .
@@ -907,7 +907,7 @@ genetic background may be instances of Mouse"""^^xsd:string ;
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#has_unit
 
-:has_unit rdf:type owl:DatatypeProperty ,
+qibo:has_unit rdf:type owl:DatatypeProperty ,
                    owl:FunctionalProperty ;
           
           rdfs:label "has unit"^^xsd:string ;
@@ -915,7 +915,7 @@ genetic background may be instances of Mouse"""^^xsd:string ;
           rdfs:range xsd:string ;
           
           rdfs:domain [ rdf:type owl:Class ;
-                        owl:unionOf ( :Quantitative_Imaging_Biomarker
+                        owl:unionOf ( qibo:Quantitative_Imaging_Biomarker
                                       owl:Thing
                                     )
                       ] .
@@ -924,7 +924,7 @@ genetic background may be instances of Mouse"""^^xsd:string ;
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#image_type
 
-:image_type rdf:type owl:DatatypeProperty ,
+qibo:image_type rdf:type owl:DatatypeProperty ,
                      owl:FunctionalProperty ;
             
             rdfs:label "image_type"^^xsd:string ;
@@ -935,7 +935,7 @@ genetic background may be instances of Mouse"""^^xsd:string ;
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#immunodeficiency_type
 
-:immunodeficiency_type rdf:type owl:DatatypeProperty ,
+qibo:immunodeficiency_type rdf:type owl:DatatypeProperty ,
                                 owl:FunctionalProperty ;
                        
                        rdfs:label "immunodeficiency_type"^^xsd:string ;
@@ -943,7 +943,7 @@ genetic background may be instances of Mouse"""^^xsd:string ;
                        rdfs:range xsd:string ;
                        
                        rdfs:domain [ rdf:type owl:Class ;
-                                     owl:unionOf ( :Xenograft
+                                     owl:unionOf ( qibo:Xenograft
                                                    owl:Thing
                                                  )
                                    ] .
@@ -952,7 +952,7 @@ genetic background may be instances of Mouse"""^^xsd:string ;
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#intravascular_half-life
 
-:intravascular_half-life rdf:type owl:DatatypeProperty ,
+qibo:intravascular_half-life rdf:type owl:DatatypeProperty ,
                                   owl:FunctionalProperty ;
                          
                          rdfs:label "intravascular half-life"^^xsd:string ;
@@ -963,7 +963,7 @@ genetic background may be instances of Mouse"""^^xsd:string ;
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#isAutomated
 
-:isAutomated rdf:type owl:DatatypeProperty ,
+qibo:isAutomated rdf:type owl:DatatypeProperty ,
                       owl:FunctionalProperty ;
              
              rdfs:label "isAutomated"^^xsd:string ;
@@ -971,7 +971,7 @@ genetic background may be instances of Mouse"""^^xsd:string ;
              rdfs:range xsd:boolean ;
              
              rdfs:domain [ rdf:type owl:Class ;
-                           owl:unionOf ( :Image_segmentation_algorithm
+                           owl:unionOf ( qibo:Image_segmentation_algorithm
                                          owl:Thing
                                        )
                          ] .
@@ -980,7 +980,7 @@ genetic background may be instances of Mouse"""^^xsd:string ;
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#is_abnormal
 
-:is_abnormal rdf:type owl:DatatypeProperty ,
+qibo:is_abnormal rdf:type owl:DatatypeProperty ,
                       owl:FunctionalProperty ;
              
              rdfs:label "is_abnormal"^^xsd:string ;
@@ -991,7 +991,7 @@ These targets may not normally be found in GO."""^^xsd:string ;
              rdfs:range xsd:boolean ;
              
              rdfs:domain [ rdf:type owl:Class ;
-                           owl:unionOf ( :Anatomical_component
+                           owl:unionOf ( qibo:Anatomical_component
                                          owl:Thing
                                        )
                          ] .
@@ -1000,7 +1000,7 @@ These targets may not normally be found in GO."""^^xsd:string ;
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#is_endogenous
 
-:is_endogenous rdf:type owl:DatatypeProperty ;
+qibo:is_endogenous rdf:type owl:DatatypeProperty ;
                
                rdfs:label "is endogenous"^^xsd:string ;
                
@@ -1010,7 +1010,7 @@ These targets may not normally be found in GO."""^^xsd:string ;
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#is_genetic
 
-:is_genetic rdf:type owl:DatatypeProperty ,
+qibo:is_genetic rdf:type owl:DatatypeProperty ,
                      owl:FunctionalProperty ;
             
             rdfs:label "is genetic"^^xsd:string ;
@@ -1018,7 +1018,7 @@ These targets may not normally be found in GO."""^^xsd:string ;
             rdfs:range xsd:boolean ;
             
             rdfs:domain [ rdf:type owl:Class ;
-                          owl:unionOf ( :Disease
+                          owl:unionOf ( qibo:Disease
                                         owl:Thing
                                       )
                         ] .
@@ -1027,7 +1027,7 @@ These targets may not normally be found in GO."""^^xsd:string ;
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#is_of_dimension
 
-:is_of_dimension rdf:type owl:DatatypeProperty ,
+qibo:is_of_dimension rdf:type owl:DatatypeProperty ,
                           owl:FunctionalProperty ;
                  
                  rdfs:label "is of dimension"^^xsd:string ;
@@ -1035,7 +1035,7 @@ These targets may not normally be found in GO."""^^xsd:string ;
                  rdfs:range xsd:string ;
                  
                  rdfs:domain [ rdf:type owl:Class ;
-                               owl:unionOf ( :Quantitative_Imaging_Biomarker
+                               owl:unionOf ( qibo:Quantitative_Imaging_Biomarker
                                              owl:Thing
                                            )
                              ] .
@@ -1044,7 +1044,7 @@ These targets may not normally be found in GO."""^^xsd:string ;
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#is_of_species
 
-:is_of_species rdf:type owl:DatatypeProperty ,
+qibo:is_of_species rdf:type owl:DatatypeProperty ,
                         owl:FunctionalProperty ;
                
                rdfs:label "is of species"^^xsd:string ;
@@ -1055,7 +1055,7 @@ These targets may not normally be found in GO."""^^xsd:string ;
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#is_pathological
 
-:is_pathological rdf:type owl:DatatypeProperty ,
+qibo:is_pathological rdf:type owl:DatatypeProperty ,
                           owl:FunctionalProperty ;
                  
                  rdfs:label "is_pathological"^^xsd:string ;
@@ -1063,8 +1063,8 @@ These targets may not normally be found in GO."""^^xsd:string ;
                  rdfs:range xsd:boolean ;
                  
                  rdfs:domain [ rdf:type owl:Class ;
-                               owl:unionOf ( :Biological_Target
-                                             :Biological_process
+                               owl:unionOf ( qibo:Biological_Target
+                                             qibo:Biological_process
                                              owl:Thing
                                            )
                              ] .
@@ -1073,7 +1073,7 @@ These targets may not normally be found in GO."""^^xsd:string ;
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#is_set_of_objects
 
-:is_set_of_objects rdf:type owl:DatatypeProperty ,
+qibo:is_set_of_objects rdf:type owl:DatatypeProperty ,
                             owl:FunctionalProperty ;
                    
                    rdfs:label "is set of objects"^^xsd:string ;
@@ -1084,7 +1084,7 @@ These targets may not normally be found in GO."""^^xsd:string ;
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#light_source
 
-:light_source rdf:type owl:DatatypeProperty ,
+qibo:light_source rdf:type owl:DatatypeProperty ,
                        owl:FunctionalProperty ;
               
               rdfs:label "light_source"^^xsd:string ;
@@ -1095,7 +1095,7 @@ These targets may not normally be found in GO."""^^xsd:string ;
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#lipophilic
 
-:lipophilic rdf:type owl:DatatypeProperty ,
+qibo:lipophilic rdf:type owl:DatatypeProperty ,
                      owl:FunctionalProperty ;
             
             rdfs:label "lipophilic"^^xsd:string ;
@@ -1103,7 +1103,7 @@ These targets may not normally be found in GO."""^^xsd:string ;
             rdfs:range xsd:boolean ;
             
             rdfs:domain [ rdf:type owl:Class ;
-                          owl:unionOf ( :Imaging_Agent
+                          owl:unionOf ( qibo:Imaging_Agent
                                         owl:Thing
                                       )
                         ] .
@@ -1112,7 +1112,7 @@ These targets may not normally be found in GO."""^^xsd:string ;
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#location
 
-:location rdf:type owl:DatatypeProperty ,
+qibo:location rdf:type owl:DatatypeProperty ,
                    owl:FunctionalProperty ;
           
           rdfs:label "location"^^xsd:string ;
@@ -1120,7 +1120,7 @@ These targets may not normally be found in GO."""^^xsd:string ;
           rdfs:range xsd:string ;
           
           rdfs:domain [ rdf:type owl:Class ;
-                        owl:unionOf ( :Xenograft
+                        owl:unionOf ( qibo:Xenograft
                                       owl:Thing
                                     )
                       ] .
@@ -1129,7 +1129,7 @@ These targets may not normally be found in GO."""^^xsd:string ;
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#molecular_weight
 
-:molecular_weight rdf:type owl:DatatypeProperty ,
+qibo:molecular_weight rdf:type owl:DatatypeProperty ,
                            owl:FunctionalProperty ;
                   
                   rdfs:label "molecular weight"^^xsd:string ;
@@ -1140,7 +1140,7 @@ These targets may not normally be found in GO."""^^xsd:string ;
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#mutant_gene
 
-:mutant_gene rdf:type owl:DatatypeProperty ,
+qibo:mutant_gene rdf:type owl:DatatypeProperty ,
                       owl:FunctionalProperty ;
              
              rdfs:label "mutant gene"^^xsd:string ;
@@ -1148,7 +1148,7 @@ These targets may not normally be found in GO."""^^xsd:string ;
              rdfs:range xsd:string ;
              
              rdfs:domain [ rdf:type owl:Class ;
-                           owl:unionOf ( :Genetically_engineered_mutant_mouse
+                           owl:unionOf ( qibo:Genetically_engineered_mutant_mouse
                                          owl:Thing
                                        )
                          ] .
@@ -1157,7 +1157,7 @@ These targets may not normally be found in GO."""^^xsd:string ;
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#name
 
-:name rdf:type owl:DatatypeProperty ,
+qibo:name rdf:type owl:DatatypeProperty ,
                owl:FunctionalProperty ;
       
       rdfs:label "name"^^xsd:string ;
@@ -1165,9 +1165,9 @@ These targets may not normally be found in GO."""^^xsd:string ;
       rdfs:range xsd:string ;
       
       rdfs:domain [ rdf:type owl:Class ;
-                    owl:unionOf ( :Adenocarcinoma
-                                  :Imaging_Subject
-                                  :Therapeutic_intervention
+                    owl:unionOf ( qibo:Adenocarcinoma
+                                  qibo:Imaging_Subject
+                                  qibo:Therapeutic_intervention
                                   owl:Thing
                                 )
                   ] .
@@ -1176,7 +1176,7 @@ These targets may not normally be found in GO."""^^xsd:string ;
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#probe_activity
 
-:probe_activity rdf:type owl:DatatypeProperty ,
+qibo:probe_activity rdf:type owl:DatatypeProperty ,
                          owl:FunctionalProperty ;
                 
                 rdfs:label "probe activity"^^xsd:string ;
@@ -1189,7 +1189,7 @@ These targets may not normally be found in GO."""^^xsd:string ;
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#radioactivity
 
-:radioactivity rdf:type owl:DatatypeProperty ,
+qibo:radioactivity rdf:type owl:DatatypeProperty ,
                         owl:FunctionalProperty ;
                
                rdfs:label "radioactivity"^^xsd:string ;
@@ -1197,7 +1197,7 @@ These targets may not normally be found in GO."""^^xsd:string ;
                rdfs:range xsd:string ;
                
                rdfs:domain [ rdf:type owl:Class ;
-                             owl:unionOf ( :Radionuclide
+                             owl:unionOf ( qibo:Radionuclide
                                            owl:Thing
                                          )
                            ] .
@@ -1206,7 +1206,7 @@ These targets may not normally be found in GO."""^^xsd:string ;
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#requires_input
 
-:requires_input rdf:type owl:DatatypeProperty ,
+qibo:requires_input rdf:type owl:DatatypeProperty ,
                          owl:FunctionalProperty ;
                 
                 rdfs:label "requires input"^^xsd:string ;
@@ -1217,7 +1217,7 @@ These targets may not normally be found in GO."""^^xsd:string ;
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#route_of_elimination
 
-:route_of_elimination rdf:type owl:DatatypeProperty ,
+qibo:route_of_elimination rdf:type owl:DatatypeProperty ,
                                owl:FunctionalProperty ;
                       
                       rdfs:label "route of elimination"^^xsd:string ;
@@ -1228,7 +1228,7 @@ These targets may not normally be found in GO."""^^xsd:string ;
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#scintillator
 
-:scintillator rdf:type owl:DatatypeProperty ,
+qibo:scintillator rdf:type owl:DatatypeProperty ,
                        owl:FunctionalProperty ;
               
               rdfs:label "scintillator"^^xsd:string ;
@@ -1236,7 +1236,7 @@ These targets may not normally be found in GO."""^^xsd:string ;
               rdfs:range xsd:string ;
               
               rdfs:domain [ rdf:type owl:Class ;
-                            owl:unionOf ( :Radionuclide_imaging
+                            owl:unionOf ( qibo:Radionuclide_imaging
                                           owl:Thing
                                         )
                           ] .
@@ -1246,7 +1246,7 @@ These targets may not normally be found in GO."""^^xsd:string ;
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#sensitivity
 
-:sensitivity rdf:type owl:DatatypeProperty ,
+qibo:sensitivity rdf:type owl:DatatypeProperty ,
                       owl:FunctionalProperty ;
              
              rdfs:label "sensitivity"^^xsd:string ;
@@ -1254,7 +1254,7 @@ These targets may not normally be found in GO."""^^xsd:string ;
              rdfs:range xsd:float ;
              
              rdfs:domain [ rdf:type owl:Class ;
-                           owl:unionOf ( :Biomarker_Use
+                           owl:unionOf ( qibo:Biomarker_Use
                                          owl:Thing
                                        )
                          ] .
@@ -1263,7 +1263,7 @@ These targets may not normally be found in GO."""^^xsd:string ;
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#strain_name
 
-:strain_name rdf:type owl:DatatypeProperty ,
+qibo:strain_name rdf:type owl:DatatypeProperty ,
                       owl:FunctionalProperty ;
              
              rdfs:label "strain name"^^xsd:string ;
@@ -1271,7 +1271,7 @@ These targets may not normally be found in GO."""^^xsd:string ;
              rdfs:range xsd:string ;
              
              rdfs:domain [ rdf:type owl:Class ;
-                           owl:unionOf ( :Mouse
+                           owl:unionOf ( qibo:Mouse
                                          owl:Thing
                                        )
                          ] .
@@ -1280,7 +1280,7 @@ These targets may not normally be found in GO."""^^xsd:string ;
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#strain_type
 
-:strain_type rdf:type owl:DatatypeProperty ,
+qibo:strain_type rdf:type owl:DatatypeProperty ,
                       owl:FunctionalProperty ;
              
              rdfs:label "strain type"^^xsd:string ;
@@ -1288,7 +1288,7 @@ These targets may not normally be found in GO."""^^xsd:string ;
              rdfs:range xsd:string ;
              
              rdfs:domain [ rdf:type owl:Class ;
-                           owl:unionOf ( :Mouse
+                           owl:unionOf ( qibo:Mouse
                                          owl:Thing
                                        )
                          ] .
@@ -1297,7 +1297,7 @@ These targets may not normally be found in GO."""^^xsd:string ;
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#to_imaging_agent
 
-:to_imaging_agent rdf:type owl:DatatypeProperty ,
+qibo:to_imaging_agent rdf:type owl:DatatypeProperty ,
                            owl:FunctionalProperty ;
                   
                   rdfs:label "to_imaging_agent"^^xsd:string ;
@@ -1311,7 +1311,7 @@ e.g. MRI with magnetic nanoparticles monitors downstream anti-angiogenic effects
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#toxicity
 
-:toxicity rdf:type owl:DatatypeProperty ,
+qibo:toxicity rdf:type owl:DatatypeProperty ,
                    owl:FunctionalProperty ;
           
           rdfs:label "toxicity"^^xsd:string ;
@@ -1319,7 +1319,7 @@ e.g. MRI with magnetic nanoparticles monitors downstream anti-angiogenic effects
           rdfs:range xsd:string ;
           
           rdfs:domain [ rdf:type owl:Class ;
-                        owl:unionOf ( :Imaging_Agent
+                        owl:unionOf ( qibo:Imaging_Agent
                                       owl:Thing
                                     )
                       ] .
@@ -1328,7 +1328,7 @@ e.g. MRI with magnetic nanoparticles monitors downstream anti-angiogenic effects
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#tracer_half_life
 
-:tracer_half_life rdf:type owl:DatatypeProperty ,
+qibo:tracer_half_life rdf:type owl:DatatypeProperty ,
                            owl:FunctionalProperty ;
                   
                   rdfs:label "tracer half life"^^xsd:string ;
@@ -1336,7 +1336,7 @@ e.g. MRI with magnetic nanoparticles monitors downstream anti-angiogenic effects
                   rdfs:range xsd:float ;
                   
                   rdfs:domain [ rdf:type owl:Class ;
-                                owl:unionOf ( :Radioisotope
+                                owl:unionOf ( qibo:Radioisotope
                                               owl:Thing
                                             )
                               ] .
@@ -1346,7 +1346,7 @@ e.g. MRI with magnetic nanoparticles monitors downstream anti-angiogenic effects
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#uses_MRI_pulse_sequence
 
-:uses_MRI_pulse_sequence rdf:type owl:DatatypeProperty ,
+qibo:uses_MRI_pulse_sequence rdf:type owl:DatatypeProperty ,
                                   owl:FunctionalProperty ;
                          
                          rdfs:label "uses MRI pulse sequence"^^xsd:string ;
@@ -1354,7 +1354,7 @@ e.g. MRI with magnetic nanoparticles monitors downstream anti-angiogenic effects
                          rdfs:range xsd:string ;
                          
                          rdfs:domain [ rdf:type owl:Class ;
-                                       owl:unionOf ( :Magnetic_resonance_imaging
+                                       owl:unionOf ( qibo:Magnetic_resonance_imaging
                                                      owl:Thing
                                                    )
                                      ] .
@@ -1363,7 +1363,7 @@ e.g. MRI with magnetic nanoparticles monitors downstream anti-angiogenic effects
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#uses_PET_reconstruction_algorithm
 
-:uses_PET_reconstruction_algorithm rdf:type owl:DatatypeProperty ,
+qibo:uses_PET_reconstruction_algorithm rdf:type owl:DatatypeProperty ,
                                             owl:FunctionalProperty ;
                                    
                                    rdfs:label "uses PET reconstruction algorithm"^^xsd:string ;
@@ -1371,7 +1371,7 @@ e.g. MRI with magnetic nanoparticles monitors downstream anti-angiogenic effects
                                    rdfs:range xsd:string ;
                                    
                                    rdfs:domain [ rdf:type owl:Class ;
-                                                 owl:unionOf ( :Positron_Emission_Tomography
+                                                 owl:unionOf ( qibo:Positron_Emission_Tomography
                                                                owl:Thing
                                                              )
                                                ] .
@@ -1388,218 +1388,218 @@ e.g. MRI with magnetic nanoparticles monitors downstream anti-angiogenic effects
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Acquisition_Device
 
-:Acquisition_Device rdf:type owl:Class .
+qibo:Acquisition_Device rdf:type owl:Class .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Activation
 
-:Activation rdf:type owl:Class ;
+qibo:Activation rdf:type owl:Class ;
             
-            rdfs:subClassOf :Functional_Measurement .
+            rdfs:subClassOf qibo:Functional_Measurement .
 
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Affine_registration_algorithm
 
-:Affine_registration_algorithm rdf:type owl:Class ;
+qibo:Affine_registration_algorithm rdf:type owl:Class ;
                                
-                               rdfs:subClassOf :Image_registration_algorithm .
+                               rdfs:subClassOf qibo:Image_registration_algorithm .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Amount
 
-:Amount rdf:type owl:Class ;
+qibo:Amount rdf:type owl:Class ;
         
-        rdfs:subClassOf :Quantitative_Imaging_Biomarker .
+        rdfs:subClassOf qibo:Quantitative_Imaging_Biomarker .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Anatomical_Measurement
 
-:Anatomical_Measurement rdf:type owl:Class ;
+qibo:Anatomical_Measurement rdf:type owl:Class ;
                         
-                        rdfs:subClassOf :Quantitative_Imaging_Biomarker .
+                        rdfs:subClassOf qibo:Quantitative_Imaging_Biomarker .
 
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Anatomical_structure
 
-:Anatomical_structure rdf:type owl:Class ;
+qibo:Anatomical_structure rdf:type owl:Class ;
                       
-                      rdfs:subClassOf :Anatomical_component .
+                      rdfs:subClassOf qibo:Anatomical_component .
 
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Area
 
-:Area rdf:type owl:Class ;
+qibo:Area rdf:type owl:Class ;
       
-      rdfs:subClassOf :Size_Parameter .
+      rdfs:subClassOf qibo:Size_Parameter .
 
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Attenuation_correction_algorithm
 
-:Attenuation_correction_algorithm rdf:type owl:Class ;
+qibo:Attenuation_correction_algorithm rdf:type owl:Class ;
                                   
-                                  rdfs:subClassOf :Noise_correction_algorithm .
+                                  rdfs:subClassOf qibo:Noise_correction_algorithm .
 
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Binding_Affinity_Biomarker
 
-:Binding_Affinity_Biomarker rdf:type owl:Class ;
+qibo:Binding_Affinity_Biomarker rdf:type owl:Class ;
                             
-                            rdfs:subClassOf :Functional_Measurement .
+                            rdfs:subClassOf qibo:Functional_Measurement .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Biodistribution
 
-:Biodistribution rdf:type owl:Class ;
+qibo:Biodistribution rdf:type owl:Class ;
                  
-                 rdfs:subClassOf :Preclinical .
+                 rdfs:subClassOf qibo:Preclinical .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Biological_Target
 
-:Biological_Target rdf:type owl:Class .
+qibo:Biological_Target rdf:type owl:Class .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Biological_macromolecule
 
-:Biological_macromolecule rdf:type owl:Class ;
+qibo:Biological_macromolecule rdf:type owl:Class ;
                           
-                          rdfs:subClassOf :Imaging_Agent .
+                          rdfs:subClassOf qibo:Imaging_Agent .
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Cerebral_blood_flow
 
-:Cerebral_blood_flow rdf:type owl:Class ;
+qibo:Cerebral_blood_flow rdf:type owl:Class ;
                      
-                     rdfs:subClassOf :Perfusion_biomarker .
+                     rdfs:subClassOf qibo:Perfusion_biomarker .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Clinical_Endpoint
 
-:Clinical_Endpoint rdf:type owl:Class ;
+qibo:Clinical_Endpoint rdf:type owl:Class ;
                    
-                   rdfs:subClassOf :Biomarker_Use ,
-                                   :Clinical_Trial_Endpoint .
+                   rdfs:subClassOf qibo:Biomarker_Use ,
+                                   qibo:Clinical_Trial_Endpoint .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Clinical_Trial_Endpoint
 
-:Clinical_Trial_Endpoint rdf:type owl:Class ;
+qibo:Clinical_Trial_Endpoint rdf:type owl:Class ;
                          
-                         rdfs:subClassOf :Drug_Development .
+                         rdfs:subClassOf qibo:Drug_Development .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Computed_Radiography
 
-:Computed_Radiography rdf:type owl:Class ;
+qibo:Computed_Radiography rdf:type owl:Class ;
                       
-                      rdfs:subClassOf :X-ray .
+                      rdfs:subClassOf qibo:X-ray .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Computed_Tomography
 
-:Computed_Tomography rdf:type owl:Class ;
+qibo:Computed_Tomography rdf:type owl:Class ;
                      
-                     rdfs:subClassOf :X-ray_imaging .
+                     rdfs:subClassOf qibo:X-ray_imaging .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Concentration_biomarker
 
-:Concentration_biomarker rdf:type owl:Class ;
+qibo:Concentration_biomarker rdf:type owl:Class ;
                          
-                         rdfs:subClassOf :Kinetic_biomarker .
+                         rdfs:subClassOf qibo:Kinetic_biomarker .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Cone_Beam_CT
 
-:Cone_Beam_CT rdf:type owl:Class ;
+qibo:Cone_Beam_CT rdf:type owl:Class ;
               
-              rdfs:subClassOf :Multi-slice_CT__Multi-row_detector_CT_ .
+              rdfs:subClassOf qibo:Multi-slice_CT__Multi-row_detector_CT_ .
 
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Cross-linked_Iron_Oxide_Nanoparticle
 
-:Cross-linked_Iron_Oxide_Nanoparticle rdf:type owl:Class ;
+qibo:Cross-linked_Iron_Oxide_Nanoparticle rdf:type owl:Class ;
                                       
-                                      rdfs:subClassOf :Superparamagnetic_Iron_Oxide_Nanoparticle .
+                                      rdfs:subClassOf qibo:Superparamagnetic_Iron_Oxide_Nanoparticle .
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Diagnosis
 
-:Diagnosis rdf:type owl:Class ;
+qibo:Diagnosis rdf:type owl:Class ;
            
-           rdfs:subClassOf :Clinical_Endpoint .
+           rdfs:subClassOf qibo:Clinical_Endpoint .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Diffusion_biomarker
 
-:Diffusion_biomarker rdf:type owl:Class ;
+qibo:Diffusion_biomarker rdf:type owl:Class ;
                      
-                     rdfs:subClassOf :Kinetic_biomarker .
+                     rdfs:subClassOf qibo:Kinetic_biomarker .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Digital_Radiography_Direct_Radiography
 
-:Digital_Radiography_Direct_Radiography rdf:type owl:Class ;
+qibo:Digital_Radiography_Direct_Radiography rdf:type owl:Class ;
                                         
-                                        rdfs:subClassOf :X-ray .
+                                        rdfs:subClassOf qibo:X-ray .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Dual_Source_CT
 
-:Dual_Source_CT rdf:type owl:Class ;
+qibo:Dual_Source_CT rdf:type owl:Class ;
                 
-                rdfs:subClassOf :Computed_Tomography .
+                rdfs:subClassOf qibo:Computed_Tomography .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Dual_energy
 
-:Dual_energy rdf:type owl:Class ;
+qibo:Dual_energy rdf:type owl:Class ;
              
-             rdfs:subClassOf :Computed_Tomography .
+             rdfs:subClassOf qibo:Computed_Tomography .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Dynamic_PET
 
-:Dynamic_PET rdf:type owl:Class ;
+qibo:Dynamic_PET rdf:type owl:Class ;
              
-             rdfs:subClassOf :Positron_Emission_Tomography .
+             rdfs:subClassOf qibo:Positron_Emission_Tomography .
 
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Electron_Beam_CT__EBCT_
 
-:Electron_Beam_CT__EBCT_ rdf:type owl:Class ;
+qibo:Electron_Beam_CT__EBCT_ rdf:type owl:Class ;
                          
-                         rdfs:subClassOf :Computed_Tomography .
+                         rdfs:subClassOf qibo:Computed_Tomography .
 
 
 
@@ -1608,142 +1608,142 @@ e.g. MRI with magnetic nanoparticles monitors downstream anti-angiogenic effects
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Ex_vivo_bodily_substance
 
-:Ex_vivo_bodily_substance rdf:type owl:Class ;
+qibo:Ex_vivo_bodily_substance rdf:type owl:Class ;
                           
-                          rdfs:subClassOf :Ex_vivo_subject .
+                          rdfs:subClassOf qibo:Ex_vivo_subject .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Ex_vivo_cells
 
-:Ex_vivo_cells rdf:type owl:Class ;
+qibo:Ex_vivo_cells rdf:type owl:Class ;
                
-               rdfs:subClassOf :Ex_vivo_subject .
+               rdfs:subClassOf qibo:Ex_vivo_subject .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Ex_vivo_subject
 
-:Ex_vivo_subject rdf:type owl:Class ;
+qibo:Ex_vivo_subject rdf:type owl:Class ;
                  
-                 rdfs:subClassOf :Imaging_Subject .
+                 rdfs:subClassOf qibo:Imaging_Subject .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Ex_vivo_tissue_biopsy
 
-:Ex_vivo_tissue_biopsy rdf:type owl:Class ;
+qibo:Ex_vivo_tissue_biopsy rdf:type owl:Class ;
                        
-                       rdfs:subClassOf :Ex_vivo_subject .
+                       rdfs:subClassOf qibo:Ex_vivo_subject .
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Film_Radiography
 
-:Film_Radiography rdf:type owl:Class ;
+qibo:Film_Radiography rdf:type owl:Class ;
                   
-                  rdfs:subClassOf :X-ray .
+                  rdfs:subClassOf qibo:X-ray .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Fluid_attenuation_inversion_recovery__FLAIR_
 
-:Fluid_attenuation_inversion_recovery__FLAIR_ rdf:type owl:Class ;
+qibo:Fluid_attenuation_inversion_recovery__FLAIR_ rdf:type owl:Class ;
                                               
-                                              rdfs:subClassOf :Acquisition_Device .
+                                              rdfs:subClassOf qibo:Acquisition_Device .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Functional_Measurement
 
-:Functional_Measurement rdf:type owl:Class ;
+qibo:Functional_Measurement rdf:type owl:Class ;
                         
-                        rdfs:subClassOf :Quantitative_Imaging_Biomarker .
+                        rdfs:subClassOf qibo:Quantitative_Imaging_Biomarker .
 
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Gadolinium
 
-:Gadolinium rdf:type owl:Class ;
+qibo:Gadolinium rdf:type owl:Class ;
             
-            rdfs:subClassOf :Atom .
+            rdfs:subClassOf qibo:Atom .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Gadolinium_
 
-:Gadolinium_ rdf:type owl:Class ;
+qibo:Gadolinium_ rdf:type owl:Class ;
              
-             rdfs:subClassOf :Magnetic_resonance_susceptibility .
+             rdfs:subClassOf qibo:Magnetic_resonance_susceptibility .
 
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Gamma_Camera
 
-:Gamma_Camera rdf:type owl:Class ;
+qibo:Gamma_Camera rdf:type owl:Class ;
               
-              rdfs:subClassOf :Acquisition_Device .
+              rdfs:subClassOf qibo:Acquisition_Device .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Gamma_camera_Anger_camera
 
-:Gamma_camera_Anger_camera rdf:type owl:Class ;
+qibo:Gamma_camera_Anger_camera rdf:type owl:Class ;
                            
-                           rdfs:subClassOf :Autoradiography .
+                           rdfs:subClassOf qibo:Autoradiography .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Gene_Knock-In_Model
 
-:Gene_Knock-In_Model rdf:type owl:Class ;
+qibo:Gene_Knock-In_Model rdf:type owl:Class ;
                      
                      rdfs:label "Gene Knock-In Model"^^xsd:string ;
                      
-                     rdfs:subClassOf :Transgenic_Model .
+                     rdfs:subClassOf qibo:Transgenic_Model .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Gene_Knock-Out_Model
 
-:Gene_Knock-Out_Model rdf:type owl:Class ;
+qibo:Gene_Knock-Out_Model rdf:type owl:Class ;
                       
                       rdfs:label "Gene Knock-Out Model"^^xsd:string ;
                       
-                      rdfs:subClassOf :Transgenic_Model .
+                      rdfs:subClassOf qibo:Transgenic_Model .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Genetically_engineered_mutant_mouse
 
-:Genetically_engineered_mutant_mouse rdf:type owl:Class ;
+qibo:Genetically_engineered_mutant_mouse rdf:type owl:Class ;
                                      
-                                     rdfs:subClassOf :Mutant_strain .
+                                     rdfs:subClassOf qibo:Mutant_strain .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Gold_Nanoparticle
 
-:Gold_Nanoparticle rdf:type owl:Class ;
+qibo:Gold_Nanoparticle rdf:type owl:Class ;
                    
-                   rdfs:subClassOf :Nanoprobe .
+                   rdfs:subClassOf qibo:Nanoprobe .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Helical_CT
 
-:Helical_CT rdf:type owl:Class ;
+qibo:Helical_CT rdf:type owl:Class ;
             
-            rdfs:subClassOf :Computed_Tomography .
+            rdfs:subClassOf qibo:Computed_Tomography .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#High_field_MRI
 
-:High_field_MRI rdf:type owl:Class ;
+qibo:High_field_MRI rdf:type owl:Class ;
                 
-                rdfs:subClassOf :Magnetic_Resonance_Imaging .
+                rdfs:subClassOf qibo:Magnetic_Resonance_Imaging .
 
 
 
@@ -1751,259 +1751,259 @@ e.g. MRI with magnetic nanoparticles monitors downstream anti-angiogenic effects
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Human_subject
 
-:Human_subject rdf:type owl:Class ;
+qibo:Human_subject rdf:type owl:Class ;
                
-               rdfs:subClassOf :Organism .
+               rdfs:subClassOf qibo:Organism .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Hyperpolarized
 
-:Hyperpolarized rdf:type owl:Class ;
+qibo:Hyperpolarized rdf:type owl:Class ;
                 
-                rdfs:subClassOf :Magnetic_resonance_susceptibility .
+                rdfs:subClassOf qibo:Magnetic_resonance_susceptibility .
 
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Image_Analysis_Technique
 
-:Image_Analysis_Technique rdf:type owl:Class ;
+qibo:Image_Analysis_Technique rdf:type owl:Class ;
                           
-                          rdfs:subClassOf :Post-processing_Algorithm .
+                          rdfs:subClassOf qibo:Post-processing_Algorithm .
 
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Image_Processing_Technique
 
-:Image_Processing_Technique rdf:type owl:Class ;
+qibo:Image_Processing_Technique rdf:type owl:Class ;
                             
-                            rdfs:subClassOf :Post-processing_Algorithm .
+                            rdfs:subClassOf qibo:Post-processing_Algorithm .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Image_Reconstruction_Algorithm
 
-:Image_Reconstruction_Algorithm rdf:type owl:Class ;
+qibo:Image_Reconstruction_Algorithm rdf:type owl:Class ;
                                 
-                                rdfs:subClassOf :Image_Visualization_Algorithm .
+                                rdfs:subClassOf qibo:Image_Visualization_Algorithm .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Image_Statistical_analysis
 
-:Image_Statistical_analysis rdf:type owl:Class ;
+qibo:Image_Statistical_analysis rdf:type owl:Class ;
                             
-                            rdfs:subClassOf :Parameter_Extraction_Algorithm .
+                            rdfs:subClassOf qibo:Parameter_Extraction_Algorithm .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Image_Visualization_Algorithm
 
-:Image_Visualization_Algorithm rdf:type owl:Class ;
+qibo:Image_Visualization_Algorithm rdf:type owl:Class ;
                                
-                               rdfs:subClassOf :Post-processing_Algorithm .
+                               rdfs:subClassOf qibo:Post-processing_Algorithm .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Image_registration_algorithm
 
-:Image_registration_algorithm rdf:type owl:Class ;
+qibo:Image_registration_algorithm rdf:type owl:Class ;
                               
-                              rdfs:subClassOf :Image_Processing_Technique .
+                              rdfs:subClassOf qibo:Image_Processing_Technique .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Image_segmentation_algorithm
 
-:Image_segmentation_algorithm rdf:type owl:Class ;
+qibo:Image_segmentation_algorithm rdf:type owl:Class ;
                               
-                              rdfs:subClassOf :Image_Processing_Technique .
+                              rdfs:subClassOf qibo:Image_Processing_Technique .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Image_thresholding_algorithm
 
-:Image_thresholding_algorithm rdf:type owl:Class ;
+qibo:Image_thresholding_algorithm rdf:type owl:Class ;
                               
-                              rdfs:subClassOf :Image_Processing_Technique .
+                              rdfs:subClassOf qibo:Image_Processing_Technique .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Imaging_Agent
 
-:Imaging_Agent rdf:type owl:Class .
+qibo:Imaging_Agent rdf:type owl:Class .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Imaging_Agent_Source_of_Emitted_Energy
 
-:Imaging_Agent_Source_of_Emitted_Energy rdf:type owl:Class ;
+qibo:Imaging_Agent_Source_of_Emitted_Energy rdf:type owl:Class ;
                                         
-                                        rdfs:subClassOf :Imaging_Agent .
+                                        rdfs:subClassOf qibo:Imaging_Agent .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Imaging_Subject
 
-:Imaging_Subject rdf:type owl:Class .
+qibo:Imaging_Subject rdf:type owl:Class .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Imaging_Technique
 
-:Imaging_Technique rdf:type owl:Class .
+qibo:Imaging_Technique rdf:type owl:Class .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#In_vitro_cell
 
-:In_vitro_cell rdf:type owl:Class ;
+qibo:In_vitro_cell rdf:type owl:Class ;
                
-               rdfs:subClassOf :In_vitro_subject .
+               rdfs:subClassOf qibo:In_vitro_subject .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#In_vitro_primary_cell
 
-:In_vitro_primary_cell rdf:type owl:Class ;
+qibo:In_vitro_primary_cell rdf:type owl:Class ;
                        
-                       rdfs:subClassOf :Cell_line .
+                       rdfs:subClassOf qibo:Cell_line .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#In_vitro_subject
 
-:In_vitro_subject rdf:type owl:Class ;
+qibo:In_vitro_subject rdf:type owl:Class ;
                   
-                  rdfs:subClassOf :Imaging_Subject .
+                  rdfs:subClassOf qibo:Imaging_Subject .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#In_vitro_tissue_biopsy
 
-:In_vitro_tissue_biopsy rdf:type owl:Class ;
+qibo:In_vitro_tissue_biopsy rdf:type owl:Class ;
                         
-                        rdfs:subClassOf :In_vitro_subject .
+                        rdfs:subClassOf qibo:In_vitro_subject .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#In_vivo_subject
 
-:In_vivo_subject rdf:type owl:Class ;
+qibo:In_vivo_subject rdf:type owl:Class ;
                  
-                 rdfs:subClassOf :Imaging_Subject .
+                 rdfs:subClassOf qibo:Imaging_Subject .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Inbred_strain
 
-:Inbred_strain rdf:type owl:Class ;
+qibo:Inbred_strain rdf:type owl:Class ;
                
-               rdfs:subClassOf :Mouse .
+               rdfs:subClassOf qibo:Mouse .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Iron
 
-:Iron rdf:type owl:Class ;
+qibo:Iron rdf:type owl:Class ;
       
-      rdfs:subClassOf :Magnetic_resonance_susceptibility .
+      rdfs:subClassOf qibo:Magnetic_resonance_susceptibility .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Iron_nanoparticle
 
-:Iron_nanoparticle rdf:type owl:Class ;
+qibo:Iron_nanoparticle rdf:type owl:Class ;
                    
-                   rdfs:subClassOf :Iron .
+                   rdfs:subClassOf qibo:Iron .
 
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Kinetic_biomarker
 
-:Kinetic_biomarker rdf:type owl:Class ;
+qibo:Kinetic_biomarker rdf:type owl:Class ;
                    
-                   rdfs:subClassOf :Functional_Measurement .
+                   rdfs:subClassOf qibo:Functional_Measurement .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Large_Superparamagnetic_Iron_Oxide_Nanoparticle
 
-:Large_Superparamagnetic_Iron_Oxide_Nanoparticle rdf:type owl:Class ;
+qibo:Large_Superparamagnetic_Iron_Oxide_Nanoparticle rdf:type owl:Class ;
                                                  
-                                                 rdfs:subClassOf :Superparamagnetic_Iron_Oxide_Nanoparticle .
+                                                 rdfs:subClassOf qibo:Superparamagnetic_Iron_Oxide_Nanoparticle .
 
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Linear_registration_algorithm
 
-:Linear_registration_algorithm rdf:type owl:Class ;
+qibo:Linear_registration_algorithm rdf:type owl:Class ;
                                
-                               rdfs:subClassOf :Image_registration_algorithm .
+                               rdfs:subClassOf qibo:Image_registration_algorithm .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Magnetic_Resonance_Imaging
 
-:Magnetic_Resonance_Imaging rdf:type owl:Class ;
+qibo:Magnetic_Resonance_Imaging rdf:type owl:Class ;
                             
-                            rdfs:subClassOf :Magnetic_resonance_imaging .
+                            rdfs:subClassOf qibo:Magnetic_resonance_imaging .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Magnetic_Resonance_Spectroscopy
 
-:Magnetic_Resonance_Spectroscopy rdf:type owl:Class ;
+qibo:Magnetic_Resonance_Spectroscopy rdf:type owl:Class ;
                                  
-                                 rdfs:subClassOf :Magnetic_resonance_imaging .
+                                 rdfs:subClassOf qibo:Magnetic_resonance_imaging .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Magnetic_resonance_angiography
 
-:Magnetic_resonance_angiography rdf:type owl:Class ;
+qibo:Magnetic_resonance_angiography rdf:type owl:Class ;
                                 
                                 rdfs:label "Magnetic resonance angiography"^^xsd:string ;
                                 
-                                rdfs:subClassOf :Magnetic_Resonance_Imaging .
+                                rdfs:subClassOf qibo:Magnetic_Resonance_Imaging .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Magnetic_resonance_imaging
 
-:Magnetic_resonance_imaging rdf:type owl:Class ;
+qibo:Magnetic_resonance_imaging rdf:type owl:Class ;
                             
-                            rdfs:subClassOf :Imaging_Technique ,
+                            rdfs:subClassOf qibo:Imaging_Technique ,
                                             [ rdf:type owl:Restriction ;
-                                              owl:onProperty :uses_MRI_pulse_sequence ;
+                                              owl:onProperty qibo:uses_MRI_pulse_sequence ;
                                               owl:hasValue "Gradient echo sequence"^^xsd:string
                                             ] ,
                                             [ rdf:type owl:Restriction ;
-                                              owl:onProperty :uses_MRI_pulse_sequence ;
+                                              owl:onProperty qibo:uses_MRI_pulse_sequence ;
                                               owl:hasValue "Saturation recovery sequence"^^xsd:string
                                             ] ,
                                             [ rdf:type owl:Restriction ;
-                                              owl:onProperty :uses_MRI_pulse_sequence ;
+                                              owl:onProperty qibo:uses_MRI_pulse_sequence ;
                                               owl:hasValue "Echo planar sequence"^^xsd:string
                                             ] ,
                                             [ rdf:type owl:Restriction ;
-                                              owl:onProperty :uses_MRI_pulse_sequence ;
+                                              owl:onProperty qibo:uses_MRI_pulse_sequence ;
                                               owl:hasValue "Spiral sequence"^^xsd:string
                                             ] ,
                                             [ rdf:type owl:Restriction ;
-                                              owl:onProperty :uses_MRI_pulse_sequence ;
+                                              owl:onProperty qibo:uses_MRI_pulse_sequence ;
                                               owl:hasValue "Spin echo sequence"^^xsd:string
                                             ] ,
                                             [ rdf:type owl:Restriction ;
-                                              owl:onProperty :uses_MRI_pulse_sequence ;
+                                              owl:onProperty qibo:uses_MRI_pulse_sequence ;
                                               owl:hasValue "Diffusion pulse sequence"^^xsd:string
                                             ] ,
                                             [ rdf:type owl:Restriction ;
-                                              owl:onProperty :uses_MRI_pulse_sequence ;
+                                              owl:onProperty qibo:uses_MRI_pulse_sequence ;
                                               owl:hasValue "Inversion recovery sequence"^^xsd:string
                                             ] .
 
@@ -2011,32 +2011,32 @@ e.g. MRI with magnetic nanoparticles monitors downstream anti-angiogenic effects
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Magnetic_resonance_susceptibility
 
-:Magnetic_resonance_susceptibility rdf:type owl:Class ;
+qibo:Magnetic_resonance_susceptibility rdf:type owl:Class ;
                                    
-                                   rdfs:subClassOf :Imaging_Agent_Source_of_Emitted_Energy .
+                                   rdfs:subClassOf qibo:Imaging_Agent_Source_of_Emitted_Energy .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Mammography
 
-:Mammography rdf:type owl:Class ;
+qibo:Mammography rdf:type owl:Class ;
              
-             rdfs:subClassOf :X-ray .
+             rdfs:subClassOf qibo:X-ray .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Manganese
 
-:Manganese rdf:type owl:Class ;
+qibo:Manganese rdf:type owl:Class ;
            
-           rdfs:subClassOf :Magnetic_resonance_susceptibility .
+           rdfs:subClassOf qibo:Magnetic_resonance_susceptibility .
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Metabolic_rate_biomarker
 
-:Metabolic_rate_biomarker rdf:type owl:Class ;
+qibo:Metabolic_rate_biomarker rdf:type owl:Class ;
                           
-                          rdfs:subClassOf :Functional_Measurement .
+                          rdfs:subClassOf qibo:Functional_Measurement .
 
 
 
@@ -2044,48 +2044,48 @@ e.g. MRI with magnetic nanoparticles monitors downstream anti-angiogenic effects
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Micro_Computed_Tomography
 
-:Micro_Computed_Tomography rdf:type owl:Class ;
+qibo:Micro_Computed_Tomography rdf:type owl:Class ;
                            
-                           rdfs:subClassOf :Tomography .
+                           rdfs:subClassOf qibo:Tomography .
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Microvascular_permeability
 
-:Microvascular_permeability rdf:type owl:Class ;
+qibo:Microvascular_permeability rdf:type owl:Class ;
                             
-                            rdfs:subClassOf :Permeability_biomarker .
+                            rdfs:subClassOf qibo:Permeability_biomarker .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Model
 
-:Model rdf:type owl:Class ;
+qibo:Model rdf:type owl:Class ;
        
-       rdfs:subClassOf :In_vivo_subject .
+       rdfs:subClassOf qibo:In_vivo_subject .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Model_of_Disease
 
-:Model_of_Disease rdf:type owl:Class ;
+qibo:Model_of_Disease rdf:type owl:Class ;
                   
-                  rdfs:subClassOf :Model .
+                  rdfs:subClassOf qibo:Model .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Molecular_Target
 
-:Molecular_Target rdf:type owl:Class ;
+qibo:Molecular_Target rdf:type owl:Class ;
                   
-                  rdfs:subClassOf :Biological_Target .
+                  rdfs:subClassOf qibo:Biological_Target .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Monkey
 
-:Monkey rdf:type owl:Class ;
+qibo:Monkey rdf:type owl:Class ;
         
-        rdfs:subClassOf :Non-human_mammalian_organism .
+        rdfs:subClassOf qibo:Non-human_mammalian_organism .
 
 
 
@@ -2093,307 +2093,307 @@ e.g. MRI with magnetic nanoparticles monitors downstream anti-angiogenic effects
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Morphological_Parameter
 
-:Morphological_Parameter rdf:type owl:Class ;
+qibo:Morphological_Parameter rdf:type owl:Class ;
                          
-                         rdfs:subClassOf :Anatomical_Measurement .
+                         rdfs:subClassOf qibo:Anatomical_Measurement .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Motion_correction_algorithm
 
-:Motion_correction_algorithm rdf:type owl:Class ;
+qibo:Motion_correction_algorithm rdf:type owl:Class ;
                              
-                             rdfs:subClassOf :Noise_correction_algorithm .
+                             rdfs:subClassOf qibo:Noise_correction_algorithm .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Mouse
 
-:Mouse rdf:type owl:Class ;
+qibo:Mouse rdf:type owl:Class ;
        
-       rdfs:subClassOf :Rodent_Model .
+       rdfs:subClassOf qibo:Rodent_Model .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Mouse_Model_of_Disease
 
-:Mouse_Model_of_Disease rdf:type owl:Class ;
+qibo:Mouse_Model_of_Disease rdf:type owl:Class ;
                         
-                        rdfs:subClassOf :Mouse .
+                        rdfs:subClassOf qibo:Mouse .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Mouse_Xenograft_Model
 
-:Mouse_Xenograft_Model rdf:type owl:Class ;
+qibo:Mouse_Xenograft_Model rdf:type owl:Class ;
                        
-                       rdfs:subClassOf :Mouse .
+                       rdfs:subClassOf qibo:Mouse .
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Multi-modality
 
-:Multi-modality rdf:type owl:Class ;
+qibo:Multi-modality rdf:type owl:Class ;
                 
-                rdfs:subClassOf :Acquisition_Device .
+                rdfs:subClassOf qibo:Acquisition_Device .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Multi-slice_CT__Multi-row_detector_CT_
 
-:Multi-slice_CT__Multi-row_detector_CT_ rdf:type owl:Class ;
+qibo:Multi-slice_CT__Multi-row_detector_CT_ rdf:type owl:Class ;
                                         
-                                        rdfs:subClassOf :Computed_Tomography .
+                                        rdfs:subClassOf qibo:Computed_Tomography .
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Multiple_tracer_PET
 
-:Multiple_tracer_PET rdf:type owl:Class ;
+qibo:Multiple_tracer_PET rdf:type owl:Class ;
                      
-                     rdfs:subClassOf :Positron_Emission_Tomography .
+                     rdfs:subClassOf qibo:Positron_Emission_Tomography .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Multispectral_imaging
 
-:Multispectral_imaging rdf:type owl:Class ;
+qibo:Multispectral_imaging rdf:type owl:Class ;
                        
-                       rdfs:subClassOf :Whole_Animal_Optical_Imaging .
+                       rdfs:subClassOf qibo:Whole_Animal_Optical_Imaging .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Mutant_strain
 
-:Mutant_strain rdf:type owl:Class ;
+qibo:Mutant_strain rdf:type owl:Class ;
                
-               rdfs:subClassOf :Mouse .
+               rdfs:subClassOf qibo:Mouse .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Nanoprobe
 
-:Nanoprobe rdf:type owl:Class ;
+qibo:Nanoprobe rdf:type owl:Class ;
            
-           rdfs:subClassOf :Imaging_Agent .
+           rdfs:subClassOf qibo:Imaging_Agent .
 
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Negative_Change
 
-:Negative_Change rdf:type owl:Class ;
+qibo:Negative_Change rdf:type owl:Class ;
                  
-                 rdfs:subClassOf :Measurement_of_Change .
+                 rdfs:subClassOf qibo:Measurement_of_Change .
 
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Neurotransmitter
 
-:Neurotransmitter rdf:type owl:Class ;
+qibo:Neurotransmitter rdf:type owl:Class ;
                   
-                  rdfs:subClassOf :Extracellular_signaling_molecule .
+                  rdfs:subClassOf qibo:Extracellular_signaling_molecule .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Nitrogen-13
 
-:Nitrogen-13 rdf:type owl:Class ;
+qibo:Nitrogen-13 rdf:type owl:Class ;
              
-             rdfs:subClassOf :Radioisotope .
+             rdfs:subClassOf qibo:Radioisotope .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Noise_correction_algorithm
 
-:Noise_correction_algorithm rdf:type owl:Class ;
+qibo:Noise_correction_algorithm rdf:type owl:Class ;
                             
-                            rdfs:subClassOf :Image_Processing_Technique .
+                            rdfs:subClassOf qibo:Image_Processing_Technique .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Non-human_mammalian_organism
 
-:Non-human_mammalian_organism rdf:type owl:Class ;
+qibo:Non-human_mammalian_organism rdf:type owl:Class ;
                               
-                              rdfs:subClassOf :Organism .
+                              rdfs:subClassOf qibo:Organism .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Non-mammalian_organism
 
-:Non-mammalian_organism rdf:type owl:Class ;
+qibo:Non-mammalian_organism rdf:type owl:Class ;
                         
-                        rdfs:subClassOf :Organism .
+                        rdfs:subClassOf qibo:Organism .
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Non-rigid_registration_algorithm
 
-:Non-rigid_registration_algorithm rdf:type owl:Class ;
+qibo:Non-rigid_registration_algorithm rdf:type owl:Class ;
                                   
-                                  rdfs:subClassOf :Image_registration_algorithm .
+                                  rdfs:subClassOf qibo:Image_registration_algorithm .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Non-specific
 
-:Non-specific rdf:type owl:Class ;
+qibo:Non-specific rdf:type owl:Class ;
               
-              rdfs:subClassOf :Biological_Target .
+              rdfs:subClassOf qibo:Biological_Target .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Nuclear_receptor
 
-:Nuclear_receptor rdf:type owl:Class ;
+qibo:Nuclear_receptor rdf:type owl:Class ;
                   
-                  rdfs:subClassOf :Intracellular_receptor .
+                  rdfs:subClassOf qibo:Intracellular_receptor .
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Organismal_Target
 
-:Organismal_Target rdf:type owl:Class ;
+qibo:Organismal_Target rdf:type owl:Class ;
                    
-                   rdfs:subClassOf :Biological_Target .
+                   rdfs:subClassOf qibo:Biological_Target .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Oxygen-15
 
-:Oxygen-15 rdf:type owl:Class ;
+qibo:Oxygen-15 rdf:type owl:Class ;
            
-           rdfs:subClassOf :Radioisotope .
+           rdfs:subClassOf qibo:Radioisotope .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#PET_CT
 
-:PET_CT rdf:type owl:Class ;
+qibo:PET_CT rdf:type owl:Class ;
         
-        rdfs:subClassOf :Multi-modality .
+        rdfs:subClassOf qibo:Multi-modality .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#PET_MRI
 
-:PET_MRI rdf:type owl:Class ;
+qibo:PET_MRI rdf:type owl:Class ;
          
-         rdfs:subClassOf :Multi-modality .
+         rdfs:subClassOf qibo:Multi-modality .
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Parameter_Extraction_Algorithm
 
-:Parameter_Extraction_Algorithm rdf:type owl:Class ;
+qibo:Parameter_Extraction_Algorithm rdf:type owl:Class ;
                                 
-                                rdfs:subClassOf :Image_Analysis_Technique .
+                                rdfs:subClassOf qibo:Image_Analysis_Technique .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Pathological_target
 
-:Pathological_target rdf:type owl:Class ;
+qibo:Pathological_target rdf:type owl:Class ;
                      
-                     rdfs:subClassOf :Protein__ .
+                     rdfs:subClassOf qibo:Protein__ .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Pathway-Level_Target
 
-:Pathway-Level_Target rdf:type owl:Class ;
+qibo:Pathway-Level_Target rdf:type owl:Class ;
                       
-                      rdfs:subClassOf :Biological_Target .
+                      rdfs:subClassOf qibo:Biological_Target .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Patient_Selection
 
-:Patient_Selection rdf:type owl:Class ;
+qibo:Patient_Selection rdf:type owl:Class ;
                    
-                   rdfs:subClassOf :Putative_Surrogate_Endpoint .
+                   rdfs:subClassOf qibo:Putative_Surrogate_Endpoint .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Perfluorocarbon_emulsion
 
-:Perfluorocarbon_emulsion rdf:type owl:Class ;
+qibo:Perfluorocarbon_emulsion rdf:type owl:Class ;
                           
-                          rdfs:subClassOf :Ultrasonic .
+                          rdfs:subClassOf qibo:Ultrasonic .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Perfusion_MRI
 
-:Perfusion_MRI rdf:type owl:Class ;
+qibo:Perfusion_MRI rdf:type owl:Class ;
                
-               rdfs:subClassOf :Magnetic_Resonance_Imaging .
+               rdfs:subClassOf qibo:Magnetic_Resonance_Imaging .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Perfusion_biomarker
 
-:Perfusion_biomarker rdf:type owl:Class ;
+qibo:Perfusion_biomarker rdf:type owl:Class ;
                      
-                     rdfs:subClassOf :Kinetic_biomarker .
+                     rdfs:subClassOf qibo:Kinetic_biomarker .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Permeability_biomarker
 
-:Permeability_biomarker rdf:type owl:Class ;
+qibo:Permeability_biomarker rdf:type owl:Class ;
                         
-                        rdfs:subClassOf :Kinetic_biomarker .
+                        rdfs:subClassOf qibo:Kinetic_biomarker .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Phantom_experimental_subject
 
-:Phantom_experimental_subject rdf:type owl:Class ;
+qibo:Phantom_experimental_subject rdf:type owl:Class ;
                               
-                              rdfs:subClassOf :Imaging_Subject .
+                              rdfs:subClassOf qibo:Imaging_Subject .
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Pharmacokinetic_profile
 
-:Pharmacokinetic_profile rdf:type owl:Class ;
+qibo:Pharmacokinetic_profile rdf:type owl:Class ;
                          
-                         rdfs:subClassOf :Preclinical .
+                         rdfs:subClassOf qibo:Preclinical .
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Physiological_temperature_biomarker
 
-:Physiological_temperature_biomarker rdf:type owl:Class ;
+qibo:Physiological_temperature_biomarker rdf:type owl:Class ;
                                      
-                                     rdfs:subClassOf :Functional_Measurement .
+                                     rdfs:subClassOf qibo:Functional_Measurement .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Pig
 
-:Pig rdf:type owl:Class ;
+qibo:Pig rdf:type owl:Class ;
      
-     rdfs:subClassOf :Non-human_mammalian_organism .
+     rdfs:subClassOf qibo:Non-human_mammalian_organism .
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Planar_Nuclear_Medicine_Imaging
 
-:Planar_Nuclear_Medicine_Imaging rdf:type owl:Class ;
+qibo:Planar_Nuclear_Medicine_Imaging rdf:type owl:Class ;
                                  
-                                 rdfs:subClassOf :Single_Photon_Imaging .
+                                 rdfs:subClassOf qibo:Single_Photon_Imaging .
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Positron_Emission_Tomography
 
-:Positron_Emission_Tomography rdf:type owl:Class ;
+qibo:Positron_Emission_Tomography rdf:type owl:Class ;
                               
-                              rdfs:subClassOf :Radionuclide_imaging ,
+                              rdfs:subClassOf qibo:Radionuclide_imaging ,
                                               [ rdf:type owl:Restriction ;
-                                                owl:onProperty :uses_PET_reconstruction_algorithm ;
+                                                owl:onProperty qibo:uses_PET_reconstruction_algorithm ;
                                                 owl:hasValue "Attenuation-weighted OSEM (AWOSEM)"^^xsd:string
                                               ] ,
                                               [ rdf:type owl:Restriction ;
-                                                owl:onProperty :uses_PET_reconstruction_algorithm ;
+                                                owl:onProperty qibo:uses_PET_reconstruction_algorithm ;
                                                 owl:hasValue "Fourier rebinning (FORE)"^^xsd:string
                                               ] ,
                                               [ rdf:type owl:Restriction ;
-                                                owl:onProperty :uses_PET_reconstruction_algorithm ;
+                                                owl:onProperty qibo:uses_PET_reconstruction_algorithm ;
                                                 owl:hasValue "Ordered-subset expection maxmization (OSEM)"^^xsd:string
                                               ] .
 
@@ -2401,49 +2401,49 @@ e.g. MRI with magnetic nanoparticles monitors downstream anti-angiogenic effects
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Post-processing_Algorithm
 
-:Post-processing_Algorithm rdf:type owl:Class .
+qibo:Post-processing_Algorithm rdf:type owl:Class .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Preclinical
 
-:Preclinical rdf:type owl:Class ;
+qibo:Preclinical rdf:type owl:Class ;
              
-             rdfs:subClassOf :Drug_Development .
+             rdfs:subClassOf qibo:Drug_Development .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Putative_Surrogate_Endpoint
 
-:Putative_Surrogate_Endpoint rdf:type owl:Class ;
+qibo:Putative_Surrogate_Endpoint rdf:type owl:Class ;
                              
-                             rdfs:subClassOf :Clinical_Trial_Endpoint .
+                             rdfs:subClassOf qibo:Clinical_Trial_Endpoint .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Quantitation_Algorithm
 
-:Quantitation_Algorithm rdf:type owl:Class ;
+qibo:Quantitation_Algorithm rdf:type owl:Class ;
                         
-                        rdfs:subClassOf :Image_Analysis_Technique .
+                        rdfs:subClassOf qibo:Image_Analysis_Technique .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Quantitative_Imaging_Biomarker
 
-:Quantitative_Imaging_Biomarker rdf:type owl:Class ;
+qibo:Quantitative_Imaging_Biomarker rdf:type owl:Class ;
                                 
                                 rdfs:subClassOf owl:Thing ,
                                                 [ rdf:type owl:Restriction ;
-                                                  owl:onProperty :has_temporality ;
+                                                  owl:onProperty qibo:has_temporality ;
                                                   owl:hasValue "serial"^^xsd:string
                                                 ] ,
                                                 [ rdf:type owl:Restriction ;
-                                                  owl:onProperty :has_temporality ;
+                                                  owl:onProperty qibo:has_temporality ;
                                                   owl:hasValue "dynamic"^^xsd:string
                                                 ] ,
                                                 [ rdf:type owl:Restriction ;
-                                                  owl:onProperty :has_temporality ;
+                                                  owl:onProperty qibo:has_temporality ;
                                                   owl:hasValue "single"^^xsd:string
                                                 ] .
 
@@ -2451,56 +2451,56 @@ e.g. MRI with magnetic nanoparticles monitors downstream anti-angiogenic effects
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Quantum_Dot_
 
-:Quantum_Dot_ rdf:type owl:Class ;
+qibo:Quantum_Dot_ rdf:type owl:Class ;
               
-              rdfs:subClassOf :Nanoprobe .
+              rdfs:subClassOf qibo:Nanoprobe .
 
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Radioisotope
 
-:Radioisotope rdf:type owl:Class ;
+qibo:Radioisotope rdf:type owl:Class ;
               
-              rdfs:subClassOf :Imaging_Agent .
+              rdfs:subClassOf qibo:Imaging_Agent .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Radiolabeled_analog
 
-:Radiolabeled_analog rdf:type owl:Class ;
+qibo:Radiolabeled_analog rdf:type owl:Class ;
                      
-                     rdfs:subClassOf :Radionuclide .
+                     rdfs:subClassOf qibo:Radionuclide .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Radiolabeled_antibody
 
-:Radiolabeled_antibody rdf:type owl:Class ;
+qibo:Radiolabeled_antibody rdf:type owl:Class ;
                        
-                       rdfs:subClassOf :Radionuclide .
+                       rdfs:subClassOf qibo:Radionuclide .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Radionuclide
 
-:Radionuclide rdf:type owl:Class ;
+qibo:Radionuclide rdf:type owl:Class ;
               
-              rdfs:subClassOf :Imaging_Agent_Source_of_Emitted_Energy ,
+              rdfs:subClassOf qibo:Imaging_Agent_Source_of_Emitted_Energy ,
                               [ rdf:type owl:Restriction ;
-                                owl:onProperty :Emitter ;
+                                owl:onProperty qibo:Emitter ;
                                 owl:hasValue "Gamma"^^xsd:string
                               ] ,
                               [ rdf:type owl:Restriction ;
-                                owl:onProperty :Emitter ;
+                                owl:onProperty qibo:Emitter ;
                                 owl:hasValue "Alpha"^^xsd:string
                               ] ,
                               [ rdf:type owl:Restriction ;
-                                owl:onProperty :Emitter ;
+                                owl:onProperty qibo:Emitter ;
                                 owl:hasValue "Multiple radiation emitter"^^xsd:string
                               ] ,
                               [ rdf:type owl:Restriction ;
-                                owl:onProperty :Emitter ;
+                                owl:onProperty qibo:Emitter ;
                                 owl:hasValue "Beta"^^xsd:string
                               ] .
 
@@ -2508,402 +2508,402 @@ e.g. MRI with magnetic nanoparticles monitors downstream anti-angiogenic effects
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Radionuclide_imaging
 
-:Radionuclide_imaging rdf:type owl:Class ;
+qibo:Radionuclide_imaging rdf:type owl:Class ;
                       
-                      rdfs:subClassOf :Imaging_Technique ,
+                      rdfs:subClassOf qibo:Imaging_Technique ,
                                       [ rdf:type owl:Restriction ;
-                                        owl:onProperty :scintillator ;
+                                        owl:onProperty qibo:scintillator ;
                                         owl:hasValue "Bismuth germanate (BGO)"^^xsd:string
                                       ] ,
                                       [ rdf:type owl:Restriction ;
-                                        owl:onProperty :scintillator ;
+                                        owl:onProperty qibo:scintillator ;
                                         owl:hasValue "Thallium-activated sodium iodide (NaI(TI))"^^xsd:string
                                       ] ,
                                       [ rdf:type owl:Restriction ;
-                                        owl:onProperty :scintillator ;
+                                        owl:onProperty qibo:scintillator ;
                                         owl:hasValue "Lutetium yttrium oxyorthosilicate (LYSO)"^^xsd:string
                                       ] ,
                                       [ rdf:type owl:Restriction ;
-                                        owl:onProperty :scintillator ;
+                                        owl:onProperty qibo:scintillator ;
                                         owl:hasValue "Lutetium oxyorthosilicate (LSO)"^^xsd:string
                                       ] .
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Rat_subject
 
-:Rat_subject rdf:type owl:Class ;
+qibo:Rat_subject rdf:type owl:Class ;
              
-             rdfs:subClassOf :Rodent_Model .
+             rdfs:subClassOf qibo:Rodent_Model .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Research_Use
 
-:Research_Use rdf:type owl:Class ;
+qibo:Research_Use rdf:type owl:Class ;
               
-              rdfs:subClassOf :Biomarker_Use .
+              rdfs:subClassOf qibo:Biomarker_Use .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Respiratory_motion_correction_algorithm
 
-:Respiratory_motion_correction_algorithm rdf:type owl:Class ;
+qibo:Respiratory_motion_correction_algorithm rdf:type owl:Class ;
                                          
-                                         rdfs:subClassOf :Motion_correction_algorithm .
+                                         rdfs:subClassOf qibo:Motion_correction_algorithm .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Response_Assessment
 
-:Response_Assessment rdf:type owl:Class ;
+qibo:Response_Assessment rdf:type owl:Class ;
                      
-                     rdfs:subClassOf :Putative_Surrogate_Endpoint .
+                     rdfs:subClassOf qibo:Putative_Surrogate_Endpoint .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Rodent_Model
 
-:Rodent_Model rdf:type owl:Class ;
+qibo:Rodent_Model rdf:type owl:Class ;
               
-              rdfs:subClassOf :Non-human_mammalian_organism .
+              rdfs:subClassOf qibo:Non-human_mammalian_organism .
 
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#SPECT_CT
 
-:SPECT_CT rdf:type owl:Class ;
+qibo:SPECT_CT rdf:type owl:Class ;
           
-          rdfs:subClassOf :Multi-modality .
+          rdfs:subClassOf qibo:Multi-modality .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Sarcoma
 
-:Sarcoma rdf:type owl:Class ;
+qibo:Sarcoma rdf:type owl:Class ;
          
-         rdfs:subClassOf :Oncologic_disease_pathology .
+         rdfs:subClassOf qibo:Oncologic_disease_pathology .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Scanning_Electron_Microscope
 
-:Scanning_Electron_Microscope rdf:type owl:Class ;
+qibo:Scanning_Electron_Microscope rdf:type owl:Class ;
                               
-                              rdfs:subClassOf :Electron_Microscope .
+                              rdfs:subClassOf qibo:Electron_Microscope .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Scanning_Probe_Microscope
 
-:Scanning_Probe_Microscope rdf:type owl:Class ;
+qibo:Scanning_Probe_Microscope rdf:type owl:Class ;
                            
-                           rdfs:subClassOf :Microscope .
+                           rdfs:subClassOf qibo:Microscope .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Scanning_Tunneling_Microscope
 
-:Scanning_Tunneling_Microscope rdf:type owl:Class ;
+qibo:Scanning_Tunneling_Microscope rdf:type owl:Class ;
                                
-                               rdfs:subClassOf :Scanning_Probe_Microscope .
+                               rdfs:subClassOf qibo:Scanning_Probe_Microscope .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Scanning_Tunneling_Microscope123
 
-:Scanning_Tunneling_Microscope123 rdf:type owl:Class ;
+qibo:Scanning_Tunneling_Microscope123 rdf:type owl:Class ;
                                   
-                                  rdfs:subClassOf :Electron_Microscope .
+                                  rdfs:subClassOf qibo:Electron_Microscope .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Scanning_confocal_microscope
 
-:Scanning_confocal_microscope rdf:type owl:Class ;
+qibo:Scanning_confocal_microscope rdf:type owl:Class ;
                               
-                              rdfs:subClassOf :Confocal_Microscope .
+                              rdfs:subClassOf qibo:Confocal_Microscope .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Scanning_optical_microscope
 
-:Scanning_optical_microscope rdf:type owl:Class ;
+qibo:Scanning_optical_microscope rdf:type owl:Class ;
                              
-                             rdfs:subClassOf :Optical_Microscope .
+                             rdfs:subClassOf qibo:Optical_Microscope .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Scatter_correction_algorithm
 
-:Scatter_correction_algorithm rdf:type owl:Class ;
+qibo:Scatter_correction_algorithm rdf:type owl:Class ;
                               
-                              rdfs:subClassOf :Noise_correction_algorithm .
+                              rdfs:subClassOf qibo:Noise_correction_algorithm .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Scintigraphy
 
-:Scintigraphy rdf:type owl:Class ;
+qibo:Scintigraphy rdf:type owl:Class ;
               
-              rdfs:subClassOf :Radionuclide_imaging .
+              rdfs:subClassOf qibo:Radionuclide_imaging .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Screening
 
-:Screening rdf:type owl:Class ;
+qibo:Screening rdf:type owl:Class ;
            
-           rdfs:subClassOf :Clinical_Endpoint .
+           rdfs:subClassOf qibo:Clinical_Endpoint .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Second_messenger
 
-:Second_messenger rdf:type owl:Class ;
+qibo:Second_messenger rdf:type owl:Class ;
                   
-                  rdfs:subClassOf :Intracellular_signaling_molecule .
+                  rdfs:subClassOf qibo:Intracellular_signaling_molecule .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Seizure
 
-:Seizure rdf:type owl:Class ;
+qibo:Seizure rdf:type owl:Class ;
          
-         rdfs:subClassOf :Neurologic_disease .
+         rdfs:subClassOf qibo:Neurologic_disease .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Selectin
 
-:Selectin rdf:type owl:Class ;
+qibo:Selectin rdf:type owl:Class ;
           
-          rdfs:subClassOf :Cell_adhesion_protein .
+          rdfs:subClassOf qibo:Cell_adhesion_protein .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Sex_differentiation_disorder
 
-:Sex_differentiation_disorder rdf:type owl:Class ;
+qibo:Sex_differentiation_disorder rdf:type owl:Class ;
                               
-                              rdfs:subClassOf :Endocrine_disease .
+                              rdfs:subClassOf qibo:Endocrine_disease .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Shape_Parameter
 
-:Shape_Parameter rdf:type owl:Class ;
+qibo:Shape_Parameter rdf:type owl:Class ;
                  
-                 rdfs:subClassOf :Morphological_Parameter .
+                 rdfs:subClassOf qibo:Morphological_Parameter .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Side_Effect
 
-:Side_Effect rdf:type owl:Class ;
+qibo:Side_Effect rdf:type owl:Class ;
              
-             rdfs:subClassOf :Preclinical .
+             rdfs:subClassOf qibo:Preclinical .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Simulated_Emission_Depletion_Microscope
 
-:Simulated_Emission_Depletion_Microscope rdf:type owl:Class ;
+qibo:Simulated_Emission_Depletion_Microscope rdf:type owl:Class ;
                                          
-                                         rdfs:subClassOf :Super_Resolution_Microscope .
+                                         rdfs:subClassOf qibo:Super_Resolution_Microscope .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Single_Photon_Emission_Computed_Tomography
 
-:Single_Photon_Emission_Computed_Tomography rdf:type owl:Class ;
+qibo:Single_Photon_Emission_Computed_Tomography rdf:type owl:Class ;
                                             
-                                            rdfs:subClassOf :Single_Photon_Imaging .
+                                            rdfs:subClassOf qibo:Single_Photon_Imaging .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Single_Photon_Imaging
 
-:Single_Photon_Imaging rdf:type owl:Class ;
+qibo:Single_Photon_Imaging rdf:type owl:Class ;
                        
-                       rdfs:subClassOf :Radionuclide_imaging .
+                       rdfs:subClassOf qibo:Radionuclide_imaging .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Size_Parameter
 
-:Size_Parameter rdf:type owl:Class ;
+qibo:Size_Parameter rdf:type owl:Class ;
                 
-                rdfs:subClassOf :Morphological_Parameter .
+                rdfs:subClassOf qibo:Morphological_Parameter .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Skin
 
-:Skin rdf:type owl:Class ;
+qibo:Skin rdf:type owl:Class ;
       
-      rdfs:subClassOf :Multicellular_Organ-level_Target .
+      rdfs:subClassOf qibo:Multicellular_Organ-level_Target .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Small_Molecule
 
-:Small_Molecule rdf:type owl:Class ;
+qibo:Small_Molecule rdf:type owl:Class ;
                 
-                rdfs:subClassOf :Imaging_Agent .
+                rdfs:subClassOf qibo:Imaging_Agent .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Small_molecule_anitcancer_drug
 
-:Small_molecule_anitcancer_drug rdf:type owl:Class ;
+qibo:Small_molecule_anitcancer_drug rdf:type owl:Class ;
                                 
-                                rdfs:subClassOf :Anticancer_therapy .
+                                rdfs:subClassOf qibo:Anticancer_therapy .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Smoothness
 
-:Smoothness rdf:type owl:Class ;
+qibo:Smoothness rdf:type owl:Class ;
             
-            rdfs:subClassOf :Texture_Parameter .
+            rdfs:subClassOf qibo:Texture_Parameter .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Somatostatin_receptor
 
-:Somatostatin_receptor rdf:type owl:Class ;
+qibo:Somatostatin_receptor rdf:type owl:Class ;
                        
-                       rdfs:subClassOf :Membrane_receptor .
+                       rdfs:subClassOf qibo:Membrane_receptor .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Spleen
 
-:Spleen rdf:type owl:Class ;
+qibo:Spleen rdf:type owl:Class ;
         
-        rdfs:subClassOf :Multicellular_Organ-level_Target .
+        rdfs:subClassOf qibo:Multicellular_Organ-level_Target .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Staging
 
-:Staging rdf:type owl:Class ;
+qibo:Staging rdf:type owl:Class ;
          
-         rdfs:subClassOf :Clinical_Endpoint .
+         rdfs:subClassOf qibo:Clinical_Endpoint .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Standard_Superparamagnetic_Iron_Oxide_Nanoparticle
 
-:Standard_Superparamagnetic_Iron_Oxide_Nanoparticle rdf:type owl:Class ;
+qibo:Standard_Superparamagnetic_Iron_Oxide_Nanoparticle rdf:type owl:Class ;
                                                     
-                                                    rdfs:subClassOf :Superparamagnetic_Iron_Oxide_Nanoparticle .
+                                                    rdfs:subClassOf qibo:Superparamagnetic_Iron_Oxide_Nanoparticle .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Stem_Cell
 
-:Stem_Cell rdf:type owl:Class ;
+qibo:Stem_Cell rdf:type owl:Class ;
            
-           rdfs:subClassOf :Cell .
+           rdfs:subClassOf qibo:Cell .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Stereoscopic
 
-:Stereoscopic rdf:type owl:Class ;
+qibo:Stereoscopic rdf:type owl:Class ;
               
-              rdfs:subClassOf :Light_Microscope .
+              rdfs:subClassOf qibo:Light_Microscope .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Stimulated_Raman_Scattering
 
-:Stimulated_Raman_Scattering rdf:type owl:Class ;
+qibo:Stimulated_Raman_Scattering rdf:type owl:Class ;
                              
-                             rdfs:subClassOf :Raman_Scattering_Spectroscopy .
+                             rdfs:subClassOf qibo:Raman_Scattering_Spectroscopy .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Stomach
 
-:Stomach rdf:type owl:Class ;
+qibo:Stomach rdf:type owl:Class ;
          
-         rdfs:subClassOf :Multicellular_Organ-level_Target .
+         rdfs:subClassOf qibo:Multicellular_Organ-level_Target .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Striatum
 
-:Striatum rdf:type owl:Class ;
+qibo:Striatum rdf:type owl:Class ;
           
-          rdfs:subClassOf :Brain .
+          rdfs:subClassOf qibo:Brain .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Subcellular_process
 
-:Subcellular_process rdf:type owl:Class ;
+qibo:Subcellular_process rdf:type owl:Class ;
                      
-                     rdfs:subClassOf :Biological_process .
+                     rdfs:subClassOf qibo:Biological_process .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Super-resolution_fluorescence_microscopy
 
-:Super-resolution_fluorescence_microscopy rdf:type owl:Class ;
+qibo:Super-resolution_fluorescence_microscopy rdf:type owl:Class ;
                                           
-                                          rdfs:subClassOf :Fluorescence_imaging .
+                                          rdfs:subClassOf qibo:Fluorescence_imaging .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Super_Resolution_Microscope
 
-:Super_Resolution_Microscope rdf:type owl:Class ;
+qibo:Super_Resolution_Microscope rdf:type owl:Class ;
                              
-                             rdfs:subClassOf :Optical_Microscope ,
+                             rdfs:subClassOf qibo:Optical_Microscope ,
                                              [ rdf:type owl:Restriction ;
-                                               owl:onProperty :super_resolution_technique ;
+                                               owl:onProperty qibo:super_resolution_technique ;
                                                owl:hasValue "RESOLOFT"^^xsd:string
                                              ] ,
                                              [ rdf:type owl:Restriction ;
-                                               owl:onProperty :super_resolution_technique ;
+                                               owl:onProperty qibo:super_resolution_technique ;
                                                owl:hasValue "STED"^^xsd:string
                                              ] ,
                                              [ rdf:type owl:Restriction ;
-                                               owl:onProperty :super_resolution_technique ;
+                                               owl:onProperty qibo:super_resolution_technique ;
                                                owl:hasValue "STORM"^^xsd:string
                                              ] ,
                                              [ rdf:type owl:Restriction ;
-                                               owl:onProperty :super_resolution_technique ;
+                                               owl:onProperty qibo:super_resolution_technique ;
                                                owl:hasValue "SIM"^^xsd:string
                                              ] ,
                                              [ rdf:type owl:Restriction ;
-                                               owl:onProperty :super_resolution_technique ;
+                                               owl:onProperty qibo:super_resolution_technique ;
                                                owl:hasValue "SSIM"^^xsd:string
                                              ] ,
                                              [ rdf:type owl:Restriction ;
-                                               owl:onProperty :super_resolution_technique ;
+                                               owl:onProperty qibo:super_resolution_technique ;
                                                owl:hasValue "PALM"^^xsd:string
                                              ] ,
                                              [ rdf:type owl:Restriction ;
-                                               owl:onProperty :super_resolution_technique ;
+                                               owl:onProperty qibo:super_resolution_technique ;
                                                owl:hasValue "2CLM"^^xsd:string
                                              ] ,
                                              [ rdf:type owl:Restriction ;
-                                               owl:onProperty :super_resolution_technique ;
+                                               owl:onProperty qibo:super_resolution_technique ;
                                                owl:hasValue "Vertico-SMI"^^xsd:string
                                              ] ,
                                              [ rdf:type owl:Restriction ;
-                                               owl:onProperty :super_resolution_technique ;
+                                               owl:onProperty qibo:super_resolution_technique ;
                                                owl:hasValue "GSD"^^xsd:string
                                              ] ,
                                              [ rdf:type owl:Restriction ;
-                                               owl:onProperty :super_resolution_technique ;
+                                               owl:onProperty qibo:super_resolution_technique ;
                                                owl:hasValue "SPEM"^^xsd:string
                                              ] ,
                                              [ rdf:type owl:Restriction ;
-                                               owl:onProperty :super_resolution_technique ;
+                                               owl:onProperty qibo:super_resolution_technique ;
                                                owl:hasValue "4Pi"^^xsd:string
                                              ] .
 
@@ -2911,335 +2911,335 @@ e.g. MRI with magnetic nanoparticles monitors downstream anti-angiogenic effects
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Superparamagnetic_Iron_Oxide_Nanoparticle
 
-:Superparamagnetic_Iron_Oxide_Nanoparticle rdf:type owl:Class ;
+qibo:Superparamagnetic_Iron_Oxide_Nanoparticle rdf:type owl:Class ;
                                            
-                                           rdfs:subClassOf :Nanoprobe .
+                                           rdfs:subClassOf qibo:Nanoprobe .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Superparamagnetic_iron_oxide_particle__SPIO_
 
-:Superparamagnetic_iron_oxide_particle__SPIO_ rdf:type owl:Class ;
+qibo:Superparamagnetic_iron_oxide_particle__SPIO_ rdf:type owl:Class ;
                                               
-                                              rdfs:subClassOf :Iron_nanoparticle .
+                                              rdfs:subClassOf qibo:Iron_nanoparticle .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Surface_Area
 
-:Surface_Area rdf:type owl:Class ;
+qibo:Surface_Area rdf:type owl:Class ;
               
-              rdfs:subClassOf :Size_Parameter .
+              rdfs:subClassOf qibo:Size_Parameter .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Surgical_procedure
 
-:Surgical_procedure rdf:type owl:Class ;
+qibo:Surgical_procedure rdf:type owl:Class ;
                     
-                    rdfs:subClassOf :Biological_Intervention .
+                    rdfs:subClassOf qibo:Biological_Intervention .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Syndrome
 
-:Syndrome rdf:type owl:Class ;
+qibo:Syndrome rdf:type owl:Class ;
           
-          rdfs:subClassOf :Disease .
+          rdfs:subClassOf qibo:Disease .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Synthetic_fluorescent_dye
 
-:Synthetic_fluorescent_dye rdf:type owl:Class ;
+qibo:Synthetic_fluorescent_dye rdf:type owl:Class ;
                            
-                           rdfs:subClassOf :Fluorescence_imaging_agent .
+                           rdfs:subClassOf qibo:Fluorescence_imaging_agent .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Syrian_Hamster
 
-:Syrian_Hamster rdf:type owl:Class ;
+qibo:Syrian_Hamster rdf:type owl:Class ;
                 
-                rdfs:subClassOf :Hamster .
+                rdfs:subClassOf qibo:Hamster .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Systemic_Target
 
-:Systemic_Target rdf:type owl:Class ;
+qibo:Systemic_Target rdf:type owl:Class ;
                  
-                 rdfs:subClassOf :Biological_Target .
+                 rdfs:subClassOf qibo:Biological_Target .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Systemic_disease_pathology
 
-:Systemic_disease_pathology rdf:type owl:Class ;
+qibo:Systemic_disease_pathology rdf:type owl:Class ;
                             
-                            rdfs:subClassOf :Disease .
+                            rdfs:subClassOf qibo:Disease .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#T1-weighted_MRI
 
-:T1-weighted_MRI rdf:type owl:Class ;
+qibo:T1-weighted_MRI rdf:type owl:Class ;
                  
-                 rdfs:subClassOf :Magnetic_Resonance_Imaging .
+                 rdfs:subClassOf qibo:Magnetic_Resonance_Imaging .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#T2-weighted_MRI
 
-:T2-weighted_MRI rdf:type owl:Class ;
+qibo:T2-weighted_MRI rdf:type owl:Class ;
                  
-                 rdfs:subClassOf :Magnetic_Resonance_Imaging .
+                 rdfs:subClassOf qibo:Magnetic_Resonance_Imaging .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#T2__weighted_MRI
 
-:T2__weighted_MRI rdf:type owl:Class ;
+qibo:T2__weighted_MRI rdf:type owl:Class ;
                   
-                  rdfs:subClassOf :T2-weighted_MRI .
+                  rdfs:subClassOf qibo:T2-weighted_MRI .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#TOF_PET
 
-:TOF_PET rdf:type owl:Class ;
+qibo:TOF_PET rdf:type owl:Class ;
          
-         rdfs:subClassOf :Positron_Emission_Tomography .
+         rdfs:subClassOf qibo:Positron_Emission_Tomography .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#T_cell_proliferation
 
-:T_cell_proliferation rdf:type owl:Class ;
+qibo:T_cell_proliferation rdf:type owl:Class ;
                       
-                      rdfs:subClassOf :Cell_proliferation .
+                      rdfs:subClassOf qibo:Cell_proliferation .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Targeted_Mutant_Mouse
 
-:Targeted_Mutant_Mouse rdf:type owl:Class ;
+qibo:Targeted_Mutant_Mouse rdf:type owl:Class ;
                        
-                       rdfs:subClassOf :Genetically_engineered_mutant_mouse .
+                       rdfs:subClassOf qibo:Genetically_engineered_mutant_mouse .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Temporo-spatially_modified_gene_expression
 
-:Temporo-spatially_modified_gene_expression rdf:type owl:Class ;
+qibo:Temporo-spatially_modified_gene_expression rdf:type owl:Class ;
                                             
-                                            rdfs:subClassOf :Induced_gene_expression .
+                                            rdfs:subClassOf qibo:Induced_gene_expression .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Tetracycline_induced_gene_expression
 
-:Tetracycline_induced_gene_expression rdf:type owl:Class ;
+qibo:Tetracycline_induced_gene_expression rdf:type owl:Class ;
                                       
-                                      rdfs:subClassOf :Induced_gene_expression .
+                                      rdfs:subClassOf qibo:Induced_gene_expression .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Tetracycline_induced_gene_silencing
 
-:Tetracycline_induced_gene_silencing rdf:type owl:Class ;
+qibo:Tetracycline_induced_gene_silencing rdf:type owl:Class ;
                                      
-                                     rdfs:subClassOf :Induced_gene_expression .
+                                     rdfs:subClassOf qibo:Induced_gene_expression .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Tetramer
 
-:Tetramer rdf:type owl:Class ;
+qibo:Tetramer rdf:type owl:Class ;
           
-          rdfs:subClassOf :Nanoprobe .
+          rdfs:subClassOf qibo:Nanoprobe .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Texture_Parameter
 
-:Texture_Parameter rdf:type owl:Class ;
+qibo:Texture_Parameter rdf:type owl:Class ;
                    
-                   rdfs:subClassOf :Morphological_Parameter .
+                   rdfs:subClassOf qibo:Morphological_Parameter .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Therapeutic_intervention
 
-:Therapeutic_intervention rdf:type owl:Class ;
+qibo:Therapeutic_intervention rdf:type owl:Class ;
                           
-                          rdfs:subClassOf :Biological_Intervention .
+                          rdfs:subClassOf qibo:Biological_Intervention .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Thickness
 
-:Thickness rdf:type owl:Class ;
+qibo:Thickness rdf:type owl:Class ;
            
-           rdfs:subClassOf :Size_Parameter .
+           rdfs:subClassOf qibo:Size_Parameter .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Thrombosis
 
-:Thrombosis rdf:type owl:Class ;
+qibo:Thrombosis rdf:type owl:Class ;
             
-            rdfs:subClassOf :Multicellular_process .
+            rdfs:subClassOf qibo:Multicellular_process .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Thymidine_kinase
 
-:Thymidine_kinase rdf:type owl:Class ;
+qibo:Thymidine_kinase rdf:type owl:Class ;
                   
-                  rdfs:subClassOf :Intracellular_protein .
+                  rdfs:subClassOf qibo:Intracellular_protein .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Thymus
 
-:Thymus rdf:type owl:Class ;
+qibo:Thymus rdf:type owl:Class ;
         
-        rdfs:subClassOf :Multicellular_Organ-level_Target .
+        rdfs:subClassOf qibo:Multicellular_Organ-level_Target .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Thyroid_disease
 
-:Thyroid_disease rdf:type owl:Class ;
+qibo:Thyroid_disease rdf:type owl:Class ;
                  
-                 rdfs:subClassOf :Endocrine_disease .
+                 rdfs:subClassOf qibo:Endocrine_disease .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Time_activity_curve__TAC_
 
-:Time_activity_curve__TAC_ rdf:type owl:Class ;
+qibo:Time_activity_curve__TAC_ rdf:type owl:Class ;
                            
-                           rdfs:subClassOf :Kinetic_biomarker .
+                           rdfs:subClassOf qibo:Kinetic_biomarker .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Time_of_flight__TOF_
 
-:Time_of_flight__TOF_ rdf:type owl:Class ;
+qibo:Time_of_flight__TOF_ rdf:type owl:Class ;
                       
-                      rdfs:subClassOf :Magnetic_Resonance_Imaging .
+                      rdfs:subClassOf qibo:Magnetic_Resonance_Imaging .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Tomography
 
-:Tomography rdf:type owl:Class ;
+qibo:Tomography rdf:type owl:Class ;
             
             rdfs:label "Tomography"^^xsd:string ;
             
-            rdfs:subClassOf :Imaging_Technique .
+            rdfs:subClassOf qibo:Imaging_Technique .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Total_Internal_Reflection_Fluorescence__TIRF_
 
-:Total_Internal_Reflection_Fluorescence__TIRF_ rdf:type owl:Class ;
+qibo:Total_Internal_Reflection_Fluorescence__TIRF_ rdf:type owl:Class ;
                                                
-                                               rdfs:subClassOf :Laser_based_Optical_Microscope .
+                                               rdfs:subClassOf qibo:Laser_based_Optical_Microscope .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Transcription
 
-:Transcription rdf:type owl:Class ;
+qibo:Transcription rdf:type owl:Class ;
                
-               rdfs:subClassOf :Subcellular_process .
+               rdfs:subClassOf qibo:Subcellular_process .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Transcription_factor
 
-:Transcription_factor rdf:type owl:Class ;
+qibo:Transcription_factor rdf:type owl:Class ;
                       
-                      rdfs:subClassOf :Intracellular_signaling_molecule .
+                      rdfs:subClassOf qibo:Intracellular_signaling_molecule .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Transduced_cell
 
-:Transduced_cell rdf:type owl:Class ;
+qibo:Transduced_cell rdf:type owl:Class ;
                  
-                 rdfs:subClassOf :In_vitro_cell .
+                 rdfs:subClassOf qibo:In_vitro_cell .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Transferase
 
-:Transferase rdf:type owl:Class ;
+qibo:Transferase rdf:type owl:Class ;
              
-             rdfs:subClassOf :Enzyme .
+             rdfs:subClassOf qibo:Enzyme .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Transgenic_Model
 
-:Transgenic_Model rdf:type owl:Class ;
+qibo:Transgenic_Model rdf:type owl:Class ;
                   
-                  rdfs:subClassOf :Model .
+                  rdfs:subClassOf qibo:Model .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Transgenic_engineering
 
-:Transgenic_engineering rdf:type owl:Class ;
+qibo:Transgenic_engineering rdf:type owl:Class ;
                         
-                        rdfs:subClassOf :Genetic_engineering .
+                        rdfs:subClassOf qibo:Genetic_engineering .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Transgenic_model
 
-:Transgenic_model rdf:type owl:Class ;
+qibo:Transgenic_model rdf:type owl:Class ;
                   
-                  rdfs:subClassOf :Targeted_Mutant_Mouse .
+                  rdfs:subClassOf qibo:Targeted_Mutant_Mouse .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Transient_Gene_Knock-Out_Model
 
-:Transient_Gene_Knock-Out_Model rdf:type owl:Class ;
+qibo:Transient_Gene_Knock-Out_Model rdf:type owl:Class ;
                                 
                                 rdfs:label "Transient Gene Knock-Out Model"^^xsd:string ;
                                 
-                                rdfs:subClassOf :Transgenic_Model .
+                                rdfs:subClassOf qibo:Transgenic_Model .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Translation
 
-:Translation rdf:type owl:Class ;
+qibo:Translation rdf:type owl:Class ;
              
-             rdfs:subClassOf :Subcellular_process .
+             rdfs:subClassOf qibo:Subcellular_process .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Transmission_Electron_Micrscope
 
-:Transmission_Electron_Micrscope rdf:type owl:Class ;
+qibo:Transmission_Electron_Micrscope rdf:type owl:Class ;
                                  
-                                 rdfs:subClassOf :Electron_Microscope ,
+                                 rdfs:subClassOf qibo:Electron_Microscope ,
                                                  [ rdf:type owl:Restriction ;
-                                                   owl:onProperty :sectioning_technique ;
+                                                   owl:onProperty qibo:sectioning_technique ;
                                                    owl:hasValue "slicing"^^xsd:string
                                                  ] ,
                                                  [ rdf:type owl:Restriction ;
-                                                   owl:onProperty :sectioning_technique ;
+                                                   owl:onProperty qibo:sectioning_technique ;
                                                    owl:hasValue "freeze-fracturing"^^xsd:string
                                                  ] ,
                                                  [ rdf:type owl:Restriction ;
-                                                   owl:onProperty :sectioning_technique ;
+                                                   owl:onProperty qibo:sectioning_technique ;
                                                    owl:hasValue "freeze-etching"^^xsd:string
                                                  ] .
 
@@ -3247,299 +3247,299 @@ e.g. MRI with magnetic nanoparticles monitors downstream anti-angiogenic effects
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Transplant_rejection
 
-:Transplant_rejection rdf:type owl:Class ;
+qibo:Transplant_rejection rdf:type owl:Class ;
                       
-                      rdfs:subClassOf :Disease .
+                      rdfs:subClassOf qibo:Disease .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Treatment_assessment
 
-:Treatment_assessment rdf:type owl:Class ;
+qibo:Treatment_assessment rdf:type owl:Class ;
                       
                       rdfs:label "Treatment assessment"^^xsd:string ;
                       
-                      rdfs:subClassOf :Clinical_Endpoint .
+                      rdfs:subClassOf qibo:Clinical_Endpoint .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Treatment_selection
 
-:Treatment_selection rdf:type owl:Class ;
+qibo:Treatment_selection rdf:type owl:Class ;
                      
-                     rdfs:subClassOf :Treatment_assessment .
+                     rdfs:subClassOf qibo:Treatment_assessment .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Tube_current_modulated_CT
 
-:Tube_current_modulated_CT rdf:type owl:Class ;
+qibo:Tube_current_modulated_CT rdf:type owl:Class ;
                            
-                           rdfs:subClassOf :Computed_Tomography .
+                           rdfs:subClassOf qibo:Computed_Tomography .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Tumor
 
-:Tumor rdf:type owl:Class ;
+qibo:Tumor rdf:type owl:Class ;
        
-       rdfs:subClassOf :Multicellular_Organ-level_Target .
+       rdfs:subClassOf qibo:Multicellular_Organ-level_Target .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Tumor_Assessment
 
-:Tumor_Assessment rdf:type owl:Class ;
+qibo:Tumor_Assessment rdf:type owl:Class ;
                   
-                  rdfs:subClassOf :Response_Assessment .
+                  rdfs:subClassOf qibo:Response_Assessment .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Tumor_cell
 
-:Tumor_cell rdf:type owl:Class ;
+qibo:Tumor_cell rdf:type owl:Class ;
             
-            rdfs:subClassOf :Cellular_Target .
+            rdfs:subClassOf qibo:Cellular_Target .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Tyrosinase
 
-:Tyrosinase rdf:type owl:Class ;
+qibo:Tyrosinase rdf:type owl:Class ;
             
-            rdfs:subClassOf :Intracellular_protein .
+            rdfs:subClassOf qibo:Intracellular_protein .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Ultra-small_superparamagnetic_iron_oxide_particle__USPIO_
 
-:Ultra-small_superparamagnetic_iron_oxide_particle__USPIO_ rdf:type owl:Class ;
+qibo:Ultra-small_superparamagnetic_iron_oxide_particle__USPIO_ rdf:type owl:Class ;
                                                            
-                                                           rdfs:subClassOf :Iron_nanoparticle .
+                                                           rdfs:subClassOf qibo:Iron_nanoparticle .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Ultrasmall_Superparamagnetic_Iron_Oxide_Nanoparticle
 
-:Ultrasmall_Superparamagnetic_Iron_Oxide_Nanoparticle rdf:type owl:Class ;
+qibo:Ultrasmall_Superparamagnetic_Iron_Oxide_Nanoparticle rdf:type owl:Class ;
                                                       
-                                                      rdfs:subClassOf :Superparamagnetic_Iron_Oxide_Nanoparticle .
+                                                      rdfs:subClassOf qibo:Superparamagnetic_Iron_Oxide_Nanoparticle .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Ultrasonic
 
-:Ultrasonic rdf:type owl:Class ;
+qibo:Ultrasonic rdf:type owl:Class ;
             
-            rdfs:subClassOf :Imaging_Agent_Source_of_Emitted_Energy .
+            rdfs:subClassOf qibo:Imaging_Agent_Source_of_Emitted_Energy .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Ultrasonic_Force_Microscope
 
-:Ultrasonic_Force_Microscope rdf:type owl:Class ;
+qibo:Ultrasonic_Force_Microscope rdf:type owl:Class ;
                              
-                             rdfs:subClassOf :Acoustic_Microscope .
+                             rdfs:subClassOf qibo:Acoustic_Microscope .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Ultrasound_imaging
 
-:Ultrasound_imaging rdf:type owl:Class ;
+qibo:Ultrasound_imaging rdf:type owl:Class ;
                     
-                    rdfs:subClassOf :Imaging_Technique .
+                    rdfs:subClassOf qibo:Imaging_Technique .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Ultraviolet_Microscope
 
-:Ultraviolet_Microscope rdf:type owl:Class ;
+qibo:Ultraviolet_Microscope rdf:type owl:Class ;
                         
-                        rdfs:subClassOf :Microscope .
+                        rdfs:subClassOf qibo:Microscope .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Urinary_Bladder
 
-:Urinary_Bladder rdf:type owl:Class ;
+qibo:Urinary_Bladder rdf:type owl:Class ;
                  
-                 rdfs:subClassOf :Multicellular_Organ-level_Target .
+                 rdfs:subClassOf qibo:Multicellular_Organ-level_Target .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Urogenital_disease
 
-:Urogenital_disease rdf:type owl:Class ;
+qibo:Urogenital_disease rdf:type owl:Class ;
                     
-                    rdfs:subClassOf :Systemic_disease_pathology .
+                    rdfs:subClassOf qibo:Systemic_disease_pathology .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Uterus
 
-:Uterus rdf:type owl:Class ;
+qibo:Uterus rdf:type owl:Class ;
         
-        rdfs:subClassOf :Multicellular_Organ-level_Target .
+        rdfs:subClassOf qibo:Multicellular_Organ-level_Target .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#VEGF
 
-:VEGF rdf:type owl:Class ;
+qibo:VEGF rdf:type owl:Class ;
       
-      rdfs:subClassOf :Growth_factor .
+      rdfs:subClassOf qibo:Growth_factor .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Vascular_Space
 
-:Vascular_Space rdf:type owl:Class ;
+qibo:Vascular_Space rdf:type owl:Class ;
                 
-                rdfs:subClassOf :Anatomical_space .
+                rdfs:subClassOf qibo:Anatomical_space .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Vascular_disease
 
-:Vascular_disease rdf:type owl:Class ;
+qibo:Vascular_disease rdf:type owl:Class ;
                   
-                  rdfs:subClassOf :Cardiovascular_disease .
+                  rdfs:subClassOf qibo:Cardiovascular_disease .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Viral_infectious_disease
 
-:Viral_infectious_disease rdf:type owl:Class ;
+qibo:Viral_infectious_disease rdf:type owl:Class ;
                           
-                          rdfs:subClassOf :Infectious_disease_pathology .
+                          rdfs:subClassOf qibo:Infectious_disease_pathology .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Vitamin
 
-:Vitamin rdf:type owl:Class ;
+qibo:Vitamin rdf:type owl:Class ;
          
-         rdfs:subClassOf :Chemically_Synthetic_Molecule .
+         rdfs:subClassOf qibo:Chemically_Synthetic_Molecule .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Volume
 
-:Volume rdf:type owl:Class ;
+qibo:Volume rdf:type owl:Class ;
         
-        rdfs:subClassOf :Size_Parameter .
+        rdfs:subClassOf qibo:Size_Parameter .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Vomiting
 
-:Vomiting rdf:type owl:Class ;
+qibo:Vomiting rdf:type owl:Class ;
           
-          rdfs:subClassOf :Gastrointestinal_disease .
+          rdfs:subClassOf qibo:Gastrointestinal_disease .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Whole_Animal_Optical_Imaging
 
-:Whole_Animal_Optical_Imaging rdf:type owl:Class ;
+qibo:Whole_Animal_Optical_Imaging rdf:type owl:Class ;
                               
-                              rdfs:subClassOf :Optical_imaging .
+                              rdfs:subClassOf qibo:Optical_imaging .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Wide_field_fluorescent_microscope
 
-:Wide_field_fluorescent_microscope rdf:type owl:Class ;
+qibo:Wide_field_fluorescent_microscope rdf:type owl:Class ;
                                    
-                                   rdfs:subClassOf :Optical_Microscope .
+                                   rdfs:subClassOf qibo:Optical_Microscope .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Widefield_fluorescence_microscopy
 
-:Widefield_fluorescence_microscopy rdf:type owl:Class ;
+qibo:Widefield_fluorescence_microscopy rdf:type owl:Class ;
                                    
-                                   rdfs:subClassOf :Fluorescence_imaging .
+                                   rdfs:subClassOf qibo:Fluorescence_imaging .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Wild_strain
 
-:Wild_strain rdf:type owl:Class ;
+qibo:Wild_strain rdf:type owl:Class ;
              
-             rdfs:subClassOf :Mouse .
+             rdfs:subClassOf qibo:Mouse .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#X-ray
 
-:X-ray rdf:type owl:Class ;
+qibo:X-ray rdf:type owl:Class ;
        
-       rdfs:subClassOf :X-ray_imaging .
+       rdfs:subClassOf qibo:X-ray_imaging .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#X-ray_Microscope
 
-:X-ray_Microscope rdf:type owl:Class ;
+qibo:X-ray_Microscope rdf:type owl:Class ;
                   
-                  rdfs:subClassOf :X-ray_imaging .
+                  rdfs:subClassOf qibo:X-ray_imaging .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#X-ray_attenuator
 
-:X-ray_attenuator rdf:type owl:Class ;
+qibo:X-ray_attenuator rdf:type owl:Class ;
                   
-                  rdfs:subClassOf :Imaging_Agent_Source_of_Emitted_Energy .
+                  rdfs:subClassOf qibo:Imaging_Agent_Source_of_Emitted_Energy .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#X-ray_imaging
 
-:X-ray_imaging rdf:type owl:Class ;
+qibo:X-ray_imaging rdf:type owl:Class ;
                
-               rdfs:subClassOf :Imaging_Technique .
+               rdfs:subClassOf qibo:Imaging_Technique .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Xenograft
 
-:Xenograft rdf:type owl:Class ;
+qibo:Xenograft rdf:type owl:Class ;
            
-           rdfs:subClassOf :Surgical_procedure .
+           rdfs:subClassOf qibo:Surgical_procedure .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Xenograft_Model
 
-:Xenograft_Model rdf:type owl:Class ;
+qibo:Xenograft_Model rdf:type owl:Class ;
                  
-                 rdfs:subClassOf :Model .
+                 rdfs:subClassOf qibo:Model .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Xenograft_rat_subject
 
-:Xenograft_rat_subject rdf:type owl:Class ;
+qibo:Xenograft_rat_subject rdf:type owl:Class ;
                        
-                       rdfs:subClassOf :Rat_subject .
+                       rdfs:subClassOf qibo:Rat_subject .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Yeast
 
-:Yeast rdf:type owl:Class ;
+qibo:Yeast rdf:type owl:Class ;
        
-       rdfs:subClassOf :Non-mammalian_organism .
+       rdfs:subClassOf qibo:Non-mammalian_organism .
 
 
 
 ###  http://www.owl-ontologies.com/Ontology1298855822.owl#Zebrafish
 
-:Zebrafish rdf:type owl:Class ;
+qibo:Zebrafish rdf:type owl:Class ;
            
-           rdfs:subClassOf :Non-mammalian_organism .
+           rdfs:subClassOf qibo:Non-mammalian_organism .
 
 
 

--- a/nidm/nidm-experiment/terms/catalog-v001.xml
+++ b/nidm/nidm-experiment/terms/catalog-v001.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+    <uri id="User Entered Import Resolution" name="http://purl.org/nidash/nidm/qibo_import.owl" uri="../../imports/qibo_import.ttl"/>
+    <uri id="User Entered Import Resolution" name="http://purl.org/nidm/iao_import.owl" uri="../../imports/iao_import.ttl"/>
     <uri id="Imports Wizard Entry" name="http://purl.obolibrary.org/nidm/iao_import.owl" uri="../../imports/iao_import.ttl"/>
 </catalog>

--- a/nidm/nidm-experiment/terms/nidm-experiment.owl
+++ b/nidm/nidm-experiment/terms/nidm-experiment.owl
@@ -647,7 +647,7 @@ nidm:Subject rdf:type owl:Class ;
 
 nidm:ExVivoSubject rdf:type owl:Class ;
 
-	   sio:SIO_001242 "qibo:ExVivoSubject" ;
+	   sio:SIO_001242 qibo:ExVivoSubject ;
            
            rdfs:subClassOf nidm:Subject .
 
@@ -656,7 +656,7 @@ nidm:ExVivoSubject rdf:type owl:Class ;
 
 nidm:InVivoSubject rdf:type owl:Class ;
 
-           sio:SIO_001242 "qibo:InVivoSubject" ;
+           sio:SIO_001242 qibo:InVivoSubject ;
 
            rdfs:subClassOf nidm:Subject .
 
@@ -665,7 +665,7 @@ nidm:InVivoSubject rdf:type owl:Class ;
 
 qibo:InVitroSubject rdf:type owl:Class ;
 
-           sio:SIO_001242 "qibo:InVitroSubject" ;
+           sio:SIO_001242 qibo:InVitroSubject ;
            
            rdfs:subClassOf nidm:Subject .
 

--- a/nidm/nidm-experiment/terms/nidm-experiment.owl
+++ b/nidm/nidm-experiment/terms/nidm-experiment.owl
@@ -647,7 +647,7 @@ nidm:Subject rdf:type owl:Class ;
 
 nidm:ExVivoSubject rdf:type owl:Class ;
 
-	   sio:SIO_001242 qibo:ExVivoSubject ;
+	   sio:SIO_001242 qibo:Ex_vivo_subject ;
            
            rdfs:subClassOf nidm:Subject .
 
@@ -656,7 +656,7 @@ nidm:ExVivoSubject rdf:type owl:Class ;
 
 nidm:InVivoSubject rdf:type owl:Class ;
 
-           sio:SIO_001242 qibo:InVivoSubject ;
+           sio:SIO_001242 qibo:In_vivo_subject ;
 
            rdfs:subClassOf nidm:Subject .
 
@@ -665,7 +665,7 @@ nidm:InVivoSubject rdf:type owl:Class ;
 
 qibo:InVitroSubject rdf:type owl:Class ;
 
-           sio:SIO_001242 qibo:InVitroSubject ;
+           sio:SIO_001242 qibo:In_vitro_subject ;
            
            rdfs:subClassOf nidm:Subject .
 
@@ -674,7 +674,7 @@ qibo:InVitroSubject rdf:type owl:Class ;
 
 nidm:Phantom rdf:type owl:Class ;
 
-     sio:SIO_001242 qibo:PhantomExperimentalSubject ;
+     sio:SIO_001242 qibo:Phantom_experimental_subject ;
            
            rdfs:subClassOf nidm:Subject .
 

--- a/nidm/nidm-experiment/terms/nidm-experiment.owl
+++ b/nidm/nidm-experiment/terms/nidm-experiment.owl
@@ -410,7 +410,7 @@ nidm:Group rdf:type owl:Class ;
 
 nidm:ImageContrastType rdf:type owl:Class ;
                          
-                         rdfs:subClassOf Entity .
+                         rdfs:subClassOf prov:Entity .
 
 
 
@@ -418,7 +418,7 @@ nidm:ImageContrastType rdf:type owl:Class ;
 
 nidm:T1Weighted rdf:type owl:Class ;
                          
-                         rdfs:subClassOf ImageContrastType .
+                         rdfs:subClassOf nidm:ImageContrastType .
 
 
 
@@ -426,7 +426,7 @@ nidm:T1Weighted rdf:type owl:Class ;
 
 nidm:T2Weighted rdf:type owl:Class ;
                          
-                         rdfs:subClassOf ImageContrastType .
+                         rdfs:subClassOf nidm:ImageContrastType .
 
 
 
@@ -434,7 +434,7 @@ nidm:T2Weighted rdf:type owl:Class ;
 
 nidm:T2*Weighted rdf:type owl:Class ;
                          
-                         rdfs:subClassOf ImageContrastType .
+                         rdfs:subClassOf nidm:ImageContrastType .
 
 
 
@@ -442,7 +442,7 @@ nidm:T2*Weighted rdf:type owl:Class ;
 
 nidm:ProtonDensityWeighted rdf:type owl:Class ;
                          
-                         rdfs:subClassOf ImageContrastType .
+                         rdfs:subClassOf nidm:ImageContrastType .
 
 
 
@@ -450,7 +450,7 @@ nidm:ProtonDensityWeighted rdf:type owl:Class ;
 
 nidm:FlowWeighted rdf:type owl:Class ;
                          
-                         rdfs:subClassOf ImageContrastType .
+                         rdfs:subClassOf nidm:ImageContrastType .
 
 
 
@@ -458,7 +458,7 @@ nidm:FlowWeighted rdf:type owl:Class ;
 
 nidm:DiffusionWeighted rdf:type owl:Class ;
                          
-                         rdfs:subClassOf ImageContrastType .
+                         rdfs:subClassOf nidm:ImageContrastType .
 
 
 
@@ -466,7 +466,7 @@ nidm:DiffusionWeighted rdf:type owl:Class ;
 
 nidm:SusceptibilityWeighted rdf:type owl:Class ;
                          
-                         rdfs:subClassOf ImageContrastType .
+                         rdfs:subClassOf nidm:ImageContrastType .
 
 
 
@@ -474,7 +474,7 @@ nidm:SusceptibilityWeighted rdf:type owl:Class ;
 
 nidm:ImageObjectFunctionType rdf:type owl:Class ;
                          
-                         rdfs:subClassOf Entity .
+                         rdfs:subClassOf prov:Entity .
 
 
 
@@ -482,7 +482,7 @@ nidm:ImageObjectFunctionType rdf:type owl:Class ;
 
 nidm:DiffusionTensorObject rdf:type owl:Class ;
                          
-                         rdfs:subClassOf ImageObjectUsageType .
+                         rdfs:subClassOf nidm:ImageObjectUsageType .
 
 
 
@@ -490,7 +490,7 @@ nidm:DiffusionTensorObject rdf:type owl:Class ;
 
 nidm:DynamicSusceptibilityContrastObject rdf:type owl:Class ;
                          
-                         rdfs:subClassOf ImageObjectUsageType .
+                         rdfs:subClassOf nidm:ImageObjectUsageType .
 
 
 
@@ -498,7 +498,7 @@ nidm:DynamicSusceptibilityContrastObject rdf:type owl:Class ;
 
 nidm:DynamicContrastEnhancementObject rdf:type owl:Class ;
                          
-                         rdfs:subClassOf ImageObjectUsageType .
+                         rdfs:subClassOf nidm:ImageObjectUsageType .
 
 
 
@@ -506,7 +506,7 @@ nidm:DynamicContrastEnhancementObject rdf:type owl:Class ;
 
 nidm:SusceptibilityWeightedImagingObject rdf:type owl:Class ;
                          
-                         rdfs:subClassOf ImageObjectUsageType .
+                         rdfs:subClassOf nidm:ImageObjectUsageType .
 
 
 
@@ -514,7 +514,7 @@ nidm:SusceptibilityWeightedImagingObject rdf:type owl:Class ;
 
 nidm:AnatomicalObject rdf:type owl:Class ;
                          
-                         rdfs:subClassOf ImageObjectUsageType .
+                         rdfs:subClassOf nidm:ImageObjectUsageType .
 
 
 
@@ -522,7 +522,7 @@ nidm:AnatomicalObject rdf:type owl:Class ;
 
 nidm:StructuralObject rdf:type owl:Class ;
                          
-                         rdfs:subClassOf ImageObjectUsageType .
+                         rdfs:subClassOf nidm:ImageObjectUsageType .
 
 
 
@@ -530,7 +530,7 @@ nidm:StructuralObject rdf:type owl:Class ;
 
 nidm:FunctionalObject rdf:type owl:Class ;
                          
-                         rdfs:subClassOf ImageObjectUsageType .
+                         rdfs:subClassOf nidm:ImageObjectUsageType .
 
 
 

--- a/nidm/nidm-experiment/terms/nidm-experiment.owl
+++ b/nidm/nidm-experiment/terms/nidm-experiment.owl
@@ -663,7 +663,7 @@ nidm:InVivoSubject rdf:type owl:Class ;
 
 ###  http://purl.org/nidash/nidm#InVitroSubject
 
-qibo:InVitroSubject rdf:type owl:Class ;
+nidm:InVitroSubject rdf:type owl:Class ;
 
            sio:SIO_001242 qibo:In_vitro_subject ;
            
@@ -681,7 +681,7 @@ nidm:Phantom rdf:type owl:Class ;
 
 ###  http://purl.org/nidash/nidm#SubjectOrganismType
 
-qibo:SubjectOrganismType rdf:type owl:Class ;
+nidm:SubjectOrganismType rdf:type owl:Class ;
            
            rdfs:subClassOf prov:Entity .
 

--- a/nidm/nidm-experiment/terms/nidm-experiment.owl
+++ b/nidm/nidm-experiment/terms/nidm-experiment.owl
@@ -430,9 +430,9 @@ nidm:T2Weighted rdf:type owl:Class ;
 
 
 
-###  http://purl.org/nidash/nidm#T2*Weighted
+###  http://purl.org/nidash/nidm#T2StarWeighted
 
-nidm:T2*Weighted rdf:type owl:Class ;
+nidm:T2StarWeighted rdf:type owl:Class ;
                          
                          rdfs:subClassOf nidm:ImageContrastType .
 

--- a/nidm/nidm-experiment/terms/nidm-experiment.owl
+++ b/nidm/nidm-experiment/terms/nidm-experiment.owl
@@ -20,6 +20,8 @@
 @prefix owl2xml: <http://www.w3.org/2006/12/owl2-xml#> .
 @prefix protege: <http://protege.stanford.edu/plugins/owl/protege#> .
 @prefix oboInOwl: <http://www.geneontology.org/formats/oboInOwl#> .
+@prefix sio: <http://semanticscience.org/resource/> .
+@prefix qibo: <http://www.owl-ontologies.com/Ontology1298855822.owl#> .
 @base <http://purl.org/nidash/nidm/nidmexperiment.owl> .
 
 <http://purl.org/nidash/nidm/nidmexperiment.owl> rdf:type owl:Ontology ;

--- a/nidm/nidm-experiment/terms/nidm-experiment.owl
+++ b/nidm/nidm-experiment/terms/nidm-experiment.owl
@@ -674,7 +674,7 @@ qibo:InVitroSubject rdf:type owl:Class ;
 
 nidm:Phantom rdf:type owl:Class ;
 
-	   sio:SIO_001242 qibo:PhantomExperimentalSubject
+     sio:SIO_001242 qibo:PhantomExperimentalSubject ;
            
            rdfs:subClassOf nidm:Subject .
 


### PR DESCRIPTION
Hi @khelm,

Thanks for pointing me to your updated `firstExp` branch in our email discussion. This PR fixes nidm-experiment.owl so that it opens in Protege without error, specifically:
 - Add missing namespace definitions for sio and qibo (cf. 06a3bf7)
 - Add missing prefixes in *prov:*Entity, *nidm:*ImageContrastType, *nidm:*ImageObjectUsageType (cf. 616cb1b)
 - Replace `*` by `Star` in `T2*Weighted` (cf. fffd0ea)
 - Add missing semicolumn (cf. cb78e62)
 - Modify identifiers used for qibo terms to comply with qibo_imports.owl (cf. 1514b85)

The following updates are also implemented: 
 - Add entries for qibo and iao in `catalog-v001.xml` so that the import load automatically (cf. 7c97bb6).
 - Remove quotes around term qname so that they are considered as terms and not strings (cf. 2afec6c)
 - Explicitly define "qibo" namespace in qibo_imports.owl (will be useful later on when this import file is copied in the main owl for release) (cf. c36fce0).
 - I have also move new terms "InVitroSubject" and "SubjectOrganismType" from "qibo" namespace to "nidm", is this right? (cf. e435b6b)

This pull request is done on your `firstExp` branch. If you accept it, your `firstExp` branch will be updated accordingly. Let me know if you have any questions/comments.

I am going to create a separate PR to discuss possible updates.